### PR TITLE
Re enable custom formatters

### DIFF
--- a/run.go
+++ b/run.go
@@ -277,6 +277,6 @@ func supportsConcurrency(format string) bool {
 	case "events", "pretty", "cucumber":
 		return false
 	default:
-		return false
+		return true // enables concurrent custom formatters to work
 	}
 }


### PR DESCRIPTION
- A recent change caused Custom Formatters to not work with concurrency. I dont think that the godog library should not allow the usuage of concurrency on Custom Formatters. 
- https://github.com/cucumber/godog/issues/237
- https://github.com/cucumber/godog/pull/204/files#diff-12f3273da1625fbe0b8ae7f4eefe2c3cR280