### PR TITLE
Fix Bug then running the example of an API, a feature version need to bump to latest reported 0.8.1 #262

### DIFF
--- a/_examples/api/features/version.feature
+++ b/_examples/api/features/version.feature
@@ -20,6 +20,6 @@ Feature: get version
     And the response should match json:
       """
       {
-        "version": "v0.7.14"
+        "version": "v0.8.1"
       }
       """


### PR DESCRIPTION
Bug then running the example of an API, a feature version need to bump to latest reported 0.8.1 #262