### PR TITLE
Added the new TestSuiteInitializer and ScenarioInitializer

### DIFF
--- a/_examples/api/README.md
+++ b/_examples/api/README.md
@@ -56,7 +56,6 @@ need to store state within steps (a response), we should introduce a structure w
 package main
 
 import (
-	"github.com/cucumber/gherkin-go/v11"
 	"github.com/cucumber/godog"
 )
 
@@ -71,11 +70,11 @@ func (a *apiFeature) theResponseCodeShouldBe(code int) error {
 	return godog.ErrPending
 }
 
-func (a *apiFeature) theResponseShouldMatchJSON(body *messages.PickleStepArgument_PickleDocString) error {
+func (a *apiFeature) theResponseShouldMatchJSON(body *godog.DocString) error {
 	return godog.ErrPending
 }
 
-func FeatureContext(s *godog.Suite) {
+func ScenarioContext(s *godog.ScenarioContext) {
 	api := &apiFeature{}
 	s.Step(`^I send "([^"]*)" request to "([^"]*)"$`, api.iSendrequestTo)
 	s.Step(`^the response code should be (\d+)$`, api.theResponseCodeShouldBe)
@@ -98,7 +97,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	"github.com/cucumber/gherkin-go/v11"
 	"github.com/cucumber/godog"
 )
 
@@ -142,7 +140,7 @@ func (a *apiFeature) theResponseCodeShouldBe(code int) error {
 	return nil
 }
 
-func (a *apiFeature) theResponseShouldMatchJSON(body *messages.PickleStepArgument_PickleDocString) error {
+func (a *apiFeature) theResponseShouldMatchJSON(body *godog.DocString) error {
 	var expected, actual []byte
 	var data interface{}
 	if err = json.Unmarshal([]byte(body.Content), &data); err != nil {
@@ -158,7 +156,7 @@ func (a *apiFeature) theResponseShouldMatchJSON(body *messages.PickleStepArgumen
 	return
 }
 
-func FeatureContext(s *godog.Suite) {
+func ScenarioContext(s *godog.ScenarioContext) {
 	api := &apiFeature{}
 
 	s.BeforeScenario(api.resetResponse)

--- a/_examples/api/api_test.go
+++ b/_examples/api/api_test.go
@@ -8,14 +8,13 @@ import (
 	"reflect"
 
 	"github.com/cucumber/godog"
-	"github.com/cucumber/messages-go/v10"
 )
 
 type apiFeature struct {
 	resp *httptest.ResponseRecorder
 }
 
-func (a *apiFeature) resetResponse(*messages.Pickle) {
+func (a *apiFeature) resetResponse(*godog.Scenario) {
 	a.resp = httptest.NewRecorder()
 }
 
@@ -51,7 +50,7 @@ func (a *apiFeature) theResponseCodeShouldBe(code int) error {
 	return nil
 }
 
-func (a *apiFeature) theResponseShouldMatchJSON(body *messages.PickleStepArgument_PickleDocString) (err error) {
+func (a *apiFeature) theResponseShouldMatchJSON(body *godog.DocString) (err error) {
 	var expected, actual interface{}
 
 	// re-encode expected response
@@ -71,7 +70,7 @@ func (a *apiFeature) theResponseShouldMatchJSON(body *messages.PickleStepArgumen
 	return nil
 }
 
-func FeatureContext(s *godog.Suite) {
+func ScenarioContext(s *godog.ScenarioContext) {
 	api := &apiFeature{}
 
 	s.BeforeScenario(api.resetResponse)

--- a/_examples/assert-godogs/features/godogs.feature
+++ b/_examples/assert-godogs/features/godogs.feature
@@ -6,10 +6,10 @@ Feature: eat godogs
 
   Scenario: Eat 5 out of 12
     Given there are 12 godogs
-    When I eat 4
+    When I eat 5
     Then there should be 7 remaining
 
   Scenario: Eat 12 out of 12
     Given there are 12 godogs
-    When I eat 11
+    When I eat 12
     Then there should be none remaining

--- a/_examples/assert-godogs/godogs_test.go
+++ b/_examples/assert-godogs/godogs_test.go
@@ -1,4 +1,3 @@
-/* file: $GOPATH/src/assert-godogs/godogs_test.go */
 package main
 
 import (
@@ -9,23 +8,24 @@ import (
 
 	"github.com/cucumber/godog"
 	"github.com/cucumber/godog/colors"
-	messages "github.com/cucumber/messages-go/v10"
 	"github.com/stretchr/testify/assert"
 )
 
-var opt = godog.Options{Output: colors.Colored(os.Stdout)}
+var opts = godog.Options{Output: colors.Colored(os.Stdout)}
 
 func init() {
-	godog.BindFlags("godog.", flag.CommandLine, &opt)
+	godog.BindFlags("godog.", flag.CommandLine, &opts)
 }
 
 func TestMain(m *testing.M) {
 	flag.Parse()
-	opt.Paths = flag.Args()
+	opts.Paths = flag.Args()
 
-	status := godog.RunWithOptions("godogs", func(s *godog.Suite) {
-		FeatureContext(s)
-	}, opt)
+	status := godog.TestSuite{
+		Name:                "godogs",
+		ScenarioInitializer: ScenarioContext,
+		Options:             &opts,
+	}.Run()
 
 	if st := m.Run(); st > status {
 		status = st
@@ -65,13 +65,13 @@ func thereShouldBeNoneRemaining() error {
 	)
 }
 
-func FeatureContext(s *godog.Suite) {
+func ScenarioContext(s *godog.ScenarioContext) {
 	s.Step(`^there are (\d+) godogs$`, thereAreGodogs)
 	s.Step(`^I eat (\d+)$`, iEat)
 	s.Step(`^there should be (\d+) remaining$`, thereShouldBeRemaining)
 	s.Step(`^there should be none remaining$`, thereShouldBeNoneRemaining)
 
-	s.BeforeScenario(func(*messages.Pickle) {
+	s.BeforeScenario(func(*godog.Scenario) {
 		Godogs = 0 // clean the state before every scenario
 	})
 }

--- a/_examples/db/api_test.go
+++ b/_examples/db/api_test.go
@@ -11,7 +11,6 @@ import (
 
 	txdb "github.com/DATA-DOG/go-txdb"
 	"github.com/cucumber/godog"
-	"github.com/cucumber/messages-go/v10"
 )
 
 func init() {
@@ -24,7 +23,7 @@ type apiFeature struct {
 	resp *httptest.ResponseRecorder
 }
 
-func (a *apiFeature) resetResponse(*messages.Pickle) {
+func (a *apiFeature) resetResponse(*godog.Scenario) {
 	a.resp = httptest.NewRecorder()
 	if a.db != nil {
 		a.db.Close()
@@ -71,7 +70,7 @@ func (a *apiFeature) theResponseCodeShouldBe(code int) error {
 	return nil
 }
 
-func (a *apiFeature) theResponseShouldMatchJSON(body *messages.PickleStepArgument_PickleDocString) (err error) {
+func (a *apiFeature) theResponseShouldMatchJSON(body *godog.DocString) (err error) {
 	var expected, actual interface{}
 
 	// re-encode expected response
@@ -91,7 +90,7 @@ func (a *apiFeature) theResponseShouldMatchJSON(body *messages.PickleStepArgumen
 	return nil
 }
 
-func (a *apiFeature) thereAreUsers(users *messages.PickleStepArgument_PickleTable) error {
+func (a *apiFeature) thereAreUsers(users *godog.Table) error {
 	var fields []string
 	var marks []string
 	head := users.Rows[0].Cells
@@ -123,7 +122,7 @@ func (a *apiFeature) thereAreUsers(users *messages.PickleStepArgument_PickleTabl
 	return nil
 }
 
-func FeatureContext(s *godog.Suite) {
+func ScenarioContext(s *godog.ScenarioContext) {
 	api := &apiFeature{}
 
 	s.BeforeScenario(api.resetResponse)

--- a/_examples/godogs/godogs_test.go
+++ b/_examples/godogs/godogs_test.go
@@ -1,4 +1,3 @@
-/* file: $GOPATH/src/godogs/godogs_test.go */
 package main
 
 import (
@@ -9,22 +8,23 @@ import (
 
 	"github.com/cucumber/godog"
 	"github.com/cucumber/godog/colors"
-	messages "github.com/cucumber/messages-go/v10"
 )
 
-var opt = godog.Options{Output: colors.Colored(os.Stdout)}
+var opts = godog.Options{Output: colors.Colored(os.Stdout)}
 
 func init() {
-	godog.BindFlags("godog.", flag.CommandLine, &opt)
+	godog.BindFlags("godog.", flag.CommandLine, &opts)
 }
 
 func TestMain(m *testing.M) {
 	flag.Parse()
-	opt.Paths = flag.Args()
+	opts.Paths = flag.Args()
 
-	status := godog.RunWithOptions("godogs", func(s *godog.Suite) {
-		FeatureContext(s)
-	}, opt)
+	status := godog.TestSuite{
+		Name:                "godogs",
+		ScenarioInitializer: ScenarioContext,
+		Options:             &opts,
+	}.Run()
 
 	if st := m.Run(); st > status {
 		status = st
@@ -52,12 +52,12 @@ func thereShouldBeRemaining(remaining int) error {
 	return nil
 }
 
-func FeatureContext(s *godog.Suite) {
+func ScenarioContext(s *godog.ScenarioContext) {
 	s.Step(`^there are (\d+) godogs$`, thereAreGodogs)
 	s.Step(`^I eat (\d+)$`, iEat)
 	s.Step(`^there should be (\d+) remaining$`, thereShouldBeRemaining)
 
-	s.BeforeScenario(func(*messages.Pickle) {
+	s.BeforeScenario(func(*godog.Scenario) {
 		Godogs = 0 // clean the state before every scenario
 	})
 }

--- a/ast.go
+++ b/ast.go
@@ -2,7 +2,7 @@ package godog
 
 import "go/ast"
 
-func astContexts(f *ast.File) []string {
+func astContexts(f *ast.File, selectName string) []string {
 	var contexts []string
 	for _, d := range f.Decls {
 		switch fun := d.(type) {
@@ -12,13 +12,13 @@ func astContexts(f *ast.File) []string {
 				case *ast.StarExpr:
 					switch x := expr.X.(type) {
 					case *ast.Ident:
-						if x.Name == "Suite" {
+						if x.Name == selectName {
 							contexts = append(contexts, fun.Name.Name)
 						}
 					case *ast.SelectorExpr:
 						switch t := x.X.(type) {
 						case *ast.Ident:
-							if t.Name == "godog" && x.Sel.Name == "Suite" {
+							if t.Name == "godog" && x.Sel.Name == selectName {
 								contexts = append(contexts, fun.Name.Name)
 							}
 						}

--- a/ast_test.go
+++ b/ast_test.go
@@ -34,7 +34,7 @@ func astContextParse(src string, t *testing.T) []string {
 		t.Fatalf("unexpected error while parsing ast: %v", err)
 	}
 
-	return astContexts(f)
+	return astContexts(f, "Suite")
 }
 
 func TestShouldGetSingleContextFromSource(t *testing.T) {

--- a/test_context.go
+++ b/test_context.go
@@ -1,0 +1,125 @@
+package godog
+
+import "github.com/cucumber/messages-go/v10"
+
+// Scenario represents the executed scenario
+type Scenario = messages.Pickle
+
+// Step represents the executed step
+type Step = messages.Pickle_PickleStep
+
+// DocString represents the DocString argument made to a step definition
+type DocString = messages.PickleStepArgument_PickleDocString
+
+// Table represents the Table argument made to a step definition
+type Table = messages.PickleStepArgument_PickleTable
+
+// TestSuiteContext allows various contexts
+// to register event handlers.
+//
+// When running a test suite, the instance of TestSuiteContext
+// is passed to all functions (contexts), which
+// have it as a first and only argument.
+//
+// Note that all event hooks does not catch panic errors
+// in order to have a trace information
+type TestSuiteContext struct {
+	beforeSuiteHandlers []func()
+	afterSuiteHandlers  []func()
+}
+
+// BeforeSuite registers a function or method
+// to be run once before suite runner.
+//
+// Use it to prepare the test suite for a spin.
+// Connect and prepare database for instance...
+func (ctx *TestSuiteContext) BeforeSuite(fn func()) {
+	ctx.beforeSuiteHandlers = append(ctx.beforeSuiteHandlers, fn)
+}
+
+// AfterSuite registers a function or method
+// to be run once after suite runner
+func (ctx *TestSuiteContext) AfterSuite(fn func()) {
+	ctx.afterSuiteHandlers = append(ctx.afterSuiteHandlers, fn)
+}
+
+// ScenarioContext allows various contexts
+// to register steps and event handlers.
+//
+// When running a scenario, the instance of ScenarioContext
+// is passed to all functions (contexts), which
+// have it as a first and only argument.
+//
+// Note that all event hooks does not catch panic errors
+// in order to have a trace information. Only step
+// executions are catching panic error since it may
+// be a context specific error.
+type ScenarioContext struct {
+	suite *Suite
+}
+
+// BeforeScenario registers a function or method
+// to be run before every scenario.
+//
+// It is a good practice to restore the default state
+// before every scenario so it would be isolated from
+// any kind of state.
+func (ctx *ScenarioContext) BeforeScenario(fn func(sc *Scenario)) {
+	ctx.suite.BeforeScenario(fn)
+}
+
+// AfterScenario registers an function or method
+// to be run after every scenario.
+func (ctx *ScenarioContext) AfterScenario(fn func(sc *Scenario, err error)) {
+	ctx.suite.AfterScenario(fn)
+}
+
+// BeforeStep registers a function or method
+// to be run before every step.
+func (ctx *ScenarioContext) BeforeStep(fn func(st *Step)) {
+	ctx.suite.BeforeStep(fn)
+}
+
+// AfterStep registers an function or method
+// to be run after every step.
+//
+// It may be convenient to return a different kind of error
+// in order to print more state details which may help
+// in case of step failure
+//
+// In some cases, for example when running a headless
+// browser, to take a screenshot after failure.
+func (ctx *ScenarioContext) AfterStep(fn func(st *Step, err error)) {
+	ctx.suite.AfterStep(fn)
+}
+
+// Step allows to register a *StepDefinition in the
+// Godog feature suite, the definition will be applied
+// to all steps matching the given Regexp expr.
+//
+// It will panic if expr is not a valid regular
+// expression or stepFunc is not a valid step
+// handler.
+//
+// The expression can be of type: *regexp.Regexp, string or []byte
+//
+// The stepFunc may accept one or several arguments of type:
+// - int, int8, int16, int32, int64
+// - float32, float64
+// - string
+// - []byte
+// - *godog.DocString
+// - *godog.Table
+//
+// The stepFunc need to return either an error or []string for multistep
+//
+// Note that if there are two definitions which may match
+// the same step, then only the first matched handler
+// will be applied.
+//
+// If none of the *StepDefinition is matched, then
+// ErrUndefined error will be returned when
+// running steps.
+func (ctx *ScenarioContext) Step(expr, stepFunc interface{}) {
+	ctx.suite.Step(expr, stepFunc)
+}

--- a/test_context_test.go
+++ b/test_context_test.go
@@ -1,0 +1,49 @@
+package godog
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/cucumber/gherkin-go/v11"
+	"github.com/cucumber/godog/colors"
+	"github.com/cucumber/messages-go/v10"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_TestContext(t *testing.T) {
+	const path = "any.feature"
+
+	var buf bytes.Buffer
+	w := colors.Uncolored(&buf)
+
+	gd, err := gherkin.ParseGherkinDocument(strings.NewReader(basicGherkinFeature), (&messages.Incrementing{}).NewId)
+	require.NoError(t, err)
+
+	pickles := gherkin.Pickles(*gd, path, (&messages.Incrementing{}).NewId)
+
+	r := runner{
+		fmt:                  progressFunc("progress", w),
+		features:             []*feature{{GherkinDocument: gd, pickles: pickles}},
+		testSuiteInitializer: nil,
+		scenarioInitializer: func(sc *ScenarioContext) {
+			sc.Step(`^one$`, func() error { return nil })
+			sc.Step(`^two$`, func() error { return nil })
+		},
+	}
+
+	failed := r.concurrent(1, func() Formatter { return progressFunc("progress", w) })
+	require.False(t, failed)
+
+	expected := `.. 2
+
+
+1 scenarios (1 passed)
+2 steps (2 passed)
+0s
+`
+
+	actual := buf.String()
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
This PR changes the setup from this:
```
func FeatureContext(s *godog.Suite){
	s.BeforeSuite(func() {})
	s.AfterSuite(func() {})

	s.BeforeScenario(func(_ *messages.Pickle) {})
	s.AfterScenario(func(_ *messages.Pickle, _ error) {})

	s.BeforeStep(func(_ *messages.Pickle_PickleStep) {})
	s.AfterStep(func(_ *messages.Pickle_PickleStep, _ error) {})

	s.Step(`^(\-*\d+\.\d+) godogs$`, godogs)
}
```

To this:
```
func InitiateSuite(ctx *godog.SuiteContext){
	ctx.BeforeSuite(func() {})
	ctx.AfterSuite(func() {})
}

func InitiateScenario(ctx *godog.ScenarioContext) {
	ctx.BeforeScenario(func(_ *godog.Scenario) {})
	ctx.AfterScenario(func(_ *godog.Scenario, _ error) {})

	ctx.BeforeStep(func(_ *godog.Step) {})
	ctx.AfterStep(func(_ *godog.Step, _ error) {})
    
	ctx.Step(`^(\-*\d+\.\d+) godogs$`, godogs)
}
```

The solution is backwards compatible and the old solution has been marked as deprecated.