### PR TITLE
Made the builder tests run in parallel

### DIFF
--- a/builder_go112_test.go
+++ b/builder_go112_test.go
@@ -4,57 +4,38 @@
 package godog_test
 
 import (
-	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-func TestGodogBuildWithVendoredGodogAndMod(t *testing.T) {
-	gopath := filepath.Join(os.TempDir(), "_gpc")
-	dir := filepath.Join(gopath, "src", "godogs")
-	err := buildTestPackage(dir, map[string]string{
+func testWithVendoredGodogAndMod(t *testing.T) {
+	builderTC := builderTestCase{}
+
+	gopath := filepath.Join(os.TempDir(), t.Name(), "_gpc")
+	defer os.RemoveAll(gopath)
+
+	builderTC.dir = filepath.Join(gopath, "src", "godogs")
+	builderTC.files = map[string]string{
 		"godogs.feature": builderFeatureFile,
 		"godogs.go":      builderMainCodeFile,
 		"godogs_test.go": builderTestFile,
 		"go.mod":         builderModFile,
-	})
-	if err != nil {
-		os.RemoveAll(gopath)
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(gopath)
-
-	pkg := filepath.Join(dir, "vendor", "github.com", "cucumber")
-	if err := os.MkdirAll(pkg, 0755); err != nil {
-		t.Fatal(err)
 	}
 
-	prevDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
+	pkg := filepath.Join(builderTC.dir, "vendor", "github.com", "cucumber")
+	err := os.MkdirAll(pkg, 0755)
+	require.Nil(t, err)
+
+	wd, err := os.Getwd()
+	require.Nil(t, err)
 
 	// symlink godog package
-	if err := os.Symlink(prevDir, filepath.Join(pkg, "godog")); err != nil {
-		t.Fatal(err)
-	}
+	err = os.Symlink(wd, filepath.Join(pkg, "godog"))
+	require.Nil(t, err)
 
-	if err := os.Chdir(dir); err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(prevDir)
-
-	cmd := buildTestCommand(t, "godogs.feature")
-
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	cmd.Env = append(envVarsWithoutGopath(), "GOPATH="+gopath)
-
-	if err := cmd.Run(); err != nil {
-		t.Log(stdout.String())
-		t.Log(stderr.String())
-		t.Fatal(err)
-	}
+	builderTC.testCmdEnv = append(envVarsWithoutGopath(), "GOPATH="+gopath)
+	builderTC.run(t)
 }


### PR DESCRIPTION
- Created a helper struct: `builderTestCase` to reuse a lot of the test code.
- Made some updates to the builder test cases so that the they can run in parallel.
- Grouped all the builder test cases in `builder_test.go` so that they all run in parallel.