### PR TITLE
Moved StepDefinition to the formatters pkg

### DIFF
--- a/formatters/fmt.go
+++ b/formatters/fmt.go
@@ -2,10 +2,9 @@ package formatters
 
 import (
 	"io"
+	"regexp"
 
 	"github.com/cucumber/messages-go/v10"
-
-	"github.com/cucumber/godog/internal/models"
 )
 
 type registeredFormatter struct {
@@ -65,15 +64,28 @@ type Formatter interface {
 	TestRunStarted()
 	Feature(*messages.GherkinDocument, string, []byte)
 	Pickle(*messages.Pickle)
-	Defined(*messages.Pickle, *messages.Pickle_PickleStep, *models.StepDefinition)
-	Failed(*messages.Pickle, *messages.Pickle_PickleStep, *models.StepDefinition, error)
-	Passed(*messages.Pickle, *messages.Pickle_PickleStep, *models.StepDefinition)
-	Skipped(*messages.Pickle, *messages.Pickle_PickleStep, *models.StepDefinition)
-	Undefined(*messages.Pickle, *messages.Pickle_PickleStep, *models.StepDefinition)
-	Pending(*messages.Pickle, *messages.Pickle_PickleStep, *models.StepDefinition)
+	Defined(*messages.Pickle, *messages.Pickle_PickleStep, *StepDefinition)
+	Failed(*messages.Pickle, *messages.Pickle_PickleStep, *StepDefinition, error)
+	Passed(*messages.Pickle, *messages.Pickle_PickleStep, *StepDefinition)
+	Skipped(*messages.Pickle, *messages.Pickle_PickleStep, *StepDefinition)
+	Undefined(*messages.Pickle, *messages.Pickle_PickleStep, *StepDefinition)
+	Pending(*messages.Pickle, *messages.Pickle_PickleStep, *StepDefinition)
 	Summary()
 }
 
 // FormatterFunc builds a formatter with given
 // suite name and io.Writer to record output
 type FormatterFunc func(string, io.Writer) Formatter
+
+// StepDefinition is a registered step definition
+// contains a StepHandler and regexp which
+// is used to match a step. Args which
+// were matched by last executed step
+//
+// This structure is passed to the formatter
+// when step is matched and is either failed
+// or successful
+type StepDefinition struct {
+	Expr    *regexp.Regexp
+	Handler interface{}
+}

--- a/internal/formatters/fmt_base.go
+++ b/internal/formatters/fmt_base.go
@@ -63,23 +63,27 @@ func (f *Basefmt) Feature(*messages.GherkinDocument, string, []byte) {}
 func (f *Basefmt) Pickle(*messages.Pickle) {}
 
 // Defined ...
-func (f *Basefmt) Defined(*messages.Pickle, *messages.Pickle_PickleStep, *models.StepDefinition) {}
+func (f *Basefmt) Defined(*messages.Pickle, *messages.Pickle_PickleStep, *formatters.StepDefinition) {
+}
 
 // Passed ...
-func (f *Basefmt) Passed(*messages.Pickle, *messages.Pickle_PickleStep, *models.StepDefinition) {}
+func (f *Basefmt) Passed(*messages.Pickle, *messages.Pickle_PickleStep, *formatters.StepDefinition) {}
 
 // Skipped ...
-func (f *Basefmt) Skipped(*messages.Pickle, *messages.Pickle_PickleStep, *models.StepDefinition) {}
+func (f *Basefmt) Skipped(*messages.Pickle, *messages.Pickle_PickleStep, *formatters.StepDefinition) {
+}
 
 // Undefined ...
-func (f *Basefmt) Undefined(*messages.Pickle, *messages.Pickle_PickleStep, *models.StepDefinition) {}
+func (f *Basefmt) Undefined(*messages.Pickle, *messages.Pickle_PickleStep, *formatters.StepDefinition) {
+}
 
 // Failed ...
-func (f *Basefmt) Failed(*messages.Pickle, *messages.Pickle_PickleStep, *models.StepDefinition, error) {
+func (f *Basefmt) Failed(*messages.Pickle, *messages.Pickle_PickleStep, *formatters.StepDefinition, error) {
 }
 
 // Pending ...
-func (f *Basefmt) Pending(*messages.Pickle, *messages.Pickle_PickleStep, *models.StepDefinition) {}
+func (f *Basefmt) Pending(*messages.Pickle, *messages.Pickle_PickleStep, *formatters.StepDefinition) {
+}
 
 // Summary ...
 func (f *Basefmt) Summary() {

--- a/internal/formatters/fmt_events.go
+++ b/internal/formatters/fmt_events.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cucumber/messages-go/v10"
 
 	"github.com/cucumber/godog/formatters"
-	"github.com/cucumber/godog/internal/models"
 	"github.com/cucumber/godog/internal/utils"
 )
 
@@ -189,7 +188,7 @@ func (f *eventsFormatter) step(pickle *messages.Pickle, pickleStep *messages.Pic
 	}
 }
 
-func (f *eventsFormatter) Defined(pickle *messages.Pickle, pickleStep *messages.Pickle_PickleStep, def *models.StepDefinition) {
+func (f *eventsFormatter) Defined(pickle *messages.Pickle, pickleStep *messages.Pickle_PickleStep, def *formatters.StepDefinition) {
 	f.Basefmt.Defined(pickle, pickleStep, def)
 
 	f.lock.Lock()
@@ -199,6 +198,8 @@ func (f *eventsFormatter) Defined(pickle *messages.Pickle, pickleStep *messages.
 	step := feature.FindStep(pickleStep.AstNodeIds[0])
 
 	if def != nil {
+		matchedDef := f.storage.MustGetStepDefintionMatch(pickleStep.AstNodeIds[0])
+
 		m := def.Expr.FindStringSubmatchIndex(pickleStep.Text)[2:]
 		var args [][2]int
 		for i := 0; i < len(m)/2; i++ {
@@ -221,7 +222,7 @@ func (f *eventsFormatter) Defined(pickle *messages.Pickle, pickleStep *messages.
 		}{
 			"StepDefinitionFound",
 			fmt.Sprintf("%s:%d", pickle.Uri, step.Location.Line),
-			DefinitionID(def),
+			DefinitionID(matchedDef),
 			args,
 		})
 	}
@@ -237,7 +238,7 @@ func (f *eventsFormatter) Defined(pickle *messages.Pickle, pickleStep *messages.
 	})
 }
 
-func (f *eventsFormatter) Passed(pickle *messages.Pickle, step *messages.Pickle_PickleStep, match *models.StepDefinition) {
+func (f *eventsFormatter) Passed(pickle *messages.Pickle, step *messages.Pickle_PickleStep, match *formatters.StepDefinition) {
 	f.Basefmt.Passed(pickle, step, match)
 
 	f.lock.Lock()
@@ -246,7 +247,7 @@ func (f *eventsFormatter) Passed(pickle *messages.Pickle, step *messages.Pickle_
 	f.step(pickle, step)
 }
 
-func (f *eventsFormatter) Skipped(pickle *messages.Pickle, step *messages.Pickle_PickleStep, match *models.StepDefinition) {
+func (f *eventsFormatter) Skipped(pickle *messages.Pickle, step *messages.Pickle_PickleStep, match *formatters.StepDefinition) {
 	f.Basefmt.Skipped(pickle, step, match)
 
 	f.lock.Lock()
@@ -255,7 +256,7 @@ func (f *eventsFormatter) Skipped(pickle *messages.Pickle, step *messages.Pickle
 	f.step(pickle, step)
 }
 
-func (f *eventsFormatter) Undefined(pickle *messages.Pickle, step *messages.Pickle_PickleStep, match *models.StepDefinition) {
+func (f *eventsFormatter) Undefined(pickle *messages.Pickle, step *messages.Pickle_PickleStep, match *formatters.StepDefinition) {
 	f.Basefmt.Undefined(pickle, step, match)
 
 	f.lock.Lock()
@@ -264,7 +265,7 @@ func (f *eventsFormatter) Undefined(pickle *messages.Pickle, step *messages.Pick
 	f.step(pickle, step)
 }
 
-func (f *eventsFormatter) Failed(pickle *messages.Pickle, step *messages.Pickle_PickleStep, match *models.StepDefinition, err error) {
+func (f *eventsFormatter) Failed(pickle *messages.Pickle, step *messages.Pickle_PickleStep, match *formatters.StepDefinition, err error) {
 	f.Basefmt.Failed(pickle, step, match, err)
 
 	f.lock.Lock()
@@ -273,7 +274,7 @@ func (f *eventsFormatter) Failed(pickle *messages.Pickle, step *messages.Pickle_
 	f.step(pickle, step)
 }
 
-func (f *eventsFormatter) Pending(pickle *messages.Pickle, step *messages.Pickle_PickleStep, match *models.StepDefinition) {
+func (f *eventsFormatter) Pending(pickle *messages.Pickle, step *messages.Pickle_PickleStep, match *formatters.StepDefinition) {
 	f.Basefmt.Pending(pickle, step, match)
 
 	f.lock.Lock()

--- a/internal/formatters/fmt_pretty.go
+++ b/internal/formatters/fmt_pretty.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/cucumber/godog/colors"
 	"github.com/cucumber/godog/formatters"
-	"github.com/cucumber/godog/internal/models"
 )
 
 func init() {
@@ -72,7 +71,7 @@ func (f *pretty) Pickle(pickle *messages.Pickle) {
 	}
 }
 
-func (f *pretty) Passed(pickle *messages.Pickle, step *messages.Pickle_PickleStep, match *models.StepDefinition) {
+func (f *pretty) Passed(pickle *messages.Pickle, step *messages.Pickle_PickleStep, match *formatters.StepDefinition) {
 	f.Basefmt.Passed(pickle, step, match)
 
 	f.lock.Lock()
@@ -81,7 +80,7 @@ func (f *pretty) Passed(pickle *messages.Pickle, step *messages.Pickle_PickleSte
 	f.printStep(pickle, step)
 }
 
-func (f *pretty) Skipped(pickle *messages.Pickle, step *messages.Pickle_PickleStep, match *models.StepDefinition) {
+func (f *pretty) Skipped(pickle *messages.Pickle, step *messages.Pickle_PickleStep, match *formatters.StepDefinition) {
 	f.Basefmt.Skipped(pickle, step, match)
 
 	f.lock.Lock()
@@ -90,7 +89,7 @@ func (f *pretty) Skipped(pickle *messages.Pickle, step *messages.Pickle_PickleSt
 	f.printStep(pickle, step)
 }
 
-func (f *pretty) Undefined(pickle *messages.Pickle, step *messages.Pickle_PickleStep, match *models.StepDefinition) {
+func (f *pretty) Undefined(pickle *messages.Pickle, step *messages.Pickle_PickleStep, match *formatters.StepDefinition) {
 	f.Basefmt.Undefined(pickle, step, match)
 
 	f.lock.Lock()
@@ -99,7 +98,7 @@ func (f *pretty) Undefined(pickle *messages.Pickle, step *messages.Pickle_Pickle
 	f.printStep(pickle, step)
 }
 
-func (f *pretty) Failed(pickle *messages.Pickle, step *messages.Pickle_PickleStep, match *models.StepDefinition, err error) {
+func (f *pretty) Failed(pickle *messages.Pickle, step *messages.Pickle_PickleStep, match *formatters.StepDefinition, err error) {
 	f.Basefmt.Failed(pickle, step, match, err)
 
 	f.lock.Lock()
@@ -108,7 +107,7 @@ func (f *pretty) Failed(pickle *messages.Pickle, step *messages.Pickle_PickleSte
 	f.printStep(pickle, step)
 }
 
-func (f *pretty) Pending(pickle *messages.Pickle, step *messages.Pickle_PickleStep, match *models.StepDefinition) {
+func (f *pretty) Pending(pickle *messages.Pickle, step *messages.Pickle_PickleStep, match *formatters.StepDefinition) {
 	f.Basefmt.Pending(pickle, step, match)
 
 	f.lock.Lock()

--- a/internal/formatters/fmt_progress.go
+++ b/internal/formatters/fmt_progress.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cucumber/messages-go/v10"
 
 	"github.com/cucumber/godog/formatters"
-	"github.com/cucumber/godog/internal/models"
 )
 
 func init() {
@@ -104,7 +103,7 @@ func (f *progress) step(pickleStepID string) {
 	}
 }
 
-func (f *progress) Passed(pickle *messages.Pickle, step *messages.Pickle_PickleStep, match *models.StepDefinition) {
+func (f *progress) Passed(pickle *messages.Pickle, step *messages.Pickle_PickleStep, match *formatters.StepDefinition) {
 	f.Basefmt.Passed(pickle, step, match)
 
 	f.lock.Lock()
@@ -113,7 +112,7 @@ func (f *progress) Passed(pickle *messages.Pickle, step *messages.Pickle_PickleS
 	f.step(step.Id)
 }
 
-func (f *progress) Skipped(pickle *messages.Pickle, step *messages.Pickle_PickleStep, match *models.StepDefinition) {
+func (f *progress) Skipped(pickle *messages.Pickle, step *messages.Pickle_PickleStep, match *formatters.StepDefinition) {
 	f.Basefmt.Skipped(pickle, step, match)
 
 	f.lock.Lock()
@@ -122,7 +121,7 @@ func (f *progress) Skipped(pickle *messages.Pickle, step *messages.Pickle_Pickle
 	f.step(step.Id)
 }
 
-func (f *progress) Undefined(pickle *messages.Pickle, step *messages.Pickle_PickleStep, match *models.StepDefinition) {
+func (f *progress) Undefined(pickle *messages.Pickle, step *messages.Pickle_PickleStep, match *formatters.StepDefinition) {
 	f.Basefmt.Undefined(pickle, step, match)
 
 	f.lock.Lock()
@@ -131,7 +130,7 @@ func (f *progress) Undefined(pickle *messages.Pickle, step *messages.Pickle_Pick
 	f.step(step.Id)
 }
 
-func (f *progress) Failed(pickle *messages.Pickle, step *messages.Pickle_PickleStep, match *models.StepDefinition, err error) {
+func (f *progress) Failed(pickle *messages.Pickle, step *messages.Pickle_PickleStep, match *formatters.StepDefinition, err error) {
 	f.Basefmt.Failed(pickle, step, match, err)
 
 	f.lock.Lock()
@@ -140,7 +139,7 @@ func (f *progress) Failed(pickle *messages.Pickle, step *messages.Pickle_PickleS
 	f.step(step.Id)
 }
 
-func (f *progress) Pending(pickle *messages.Pickle, step *messages.Pickle_PickleStep, match *models.StepDefinition) {
+func (f *progress) Pending(pickle *messages.Pickle, step *messages.Pickle_PickleStep, match *formatters.StepDefinition) {
 	f.Basefmt.Pending(pickle, step, match)
 
 	f.lock.Lock()

--- a/internal/models/stepdef.go
+++ b/internal/models/stepdef.go
@@ -3,27 +3,21 @@ package models
 import (
 	"fmt"
 	"reflect"
-	"regexp"
 	"strconv"
 
 	"github.com/cucumber/messages-go/v10"
+
+	"github.com/cucumber/godog/formatters"
 )
 
 var typeOfBytes = reflect.TypeOf([]byte(nil))
 
-// StepDefinition is a registered step definition
-// contains a StepHandler and regexp which
-// is used to match a step. Args which
-// were matched by last executed step
-//
-// This structure is passed to the formatter
-// when step is matched and is either failed
-// or successful
+// StepDefinition ...
 type StepDefinition struct {
+	formatters.StepDefinition
+
 	Args         []interface{}
 	HandlerValue reflect.Value
-	Expr         *regexp.Regexp
-	Handler      interface{}
 
 	// multistep related
 	Nested    bool
@@ -172,4 +166,13 @@ func (sd *StepDefinition) shouldBeString(idx int) (string, error) {
 		return "", fmt.Errorf(`cannot convert argument %d: "%v" of type "%T" to string`, idx, arg, arg)
 	}
 	return s, nil
+}
+
+// GetInternalStepDefinition ...
+func (sd *StepDefinition) GetInternalStepDefinition() *formatters.StepDefinition {
+	if sd == nil {
+		return nil
+	}
+
+	return &sd.StepDefinition
 }

--- a/internal/models/stepdef_test.go
+++ b/internal/models/stepdef_test.go
@@ -5,15 +5,19 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cucumber/godog/internal/models"
 	"github.com/cucumber/messages-go/v10"
+
+	"github.com/cucumber/godog/formatters"
+	"github.com/cucumber/godog/internal/models"
 )
 
 func TestShouldSupportIntTypes(t *testing.T) {
 	fn := func(a int64, b int32, c int16, d int8) error { return nil }
 
 	def := &models.StepDefinition{
-		Handler:      fn,
+		StepDefinition: formatters.StepDefinition{
+			Handler: fn,
+		},
 		HandlerValue: reflect.ValueOf(fn),
 	}
 
@@ -32,7 +36,9 @@ func TestShouldSupportFloatTypes(t *testing.T) {
 	fn := func(a float64, b float32) error { return nil }
 
 	def := &models.StepDefinition{
-		Handler:      fn,
+		StepDefinition: formatters.StepDefinition{
+			Handler: fn,
+		},
 		HandlerValue: reflect.ValueOf(fn),
 	}
 
@@ -52,16 +58,36 @@ func TestShouldNotSupportOtherPointerTypesThanGherkin(t *testing.T) {
 	fn2 := func(a *messages.PickleStepArgument_PickleDocString) error { return nil }
 	fn3 := func(a *messages.PickleStepArgument_PickleTable) error { return nil }
 
-	def1 := &models.StepDefinition{Handler: fn1, HandlerValue: reflect.ValueOf(fn1), Args: []interface{}{(*int)(nil)}}
-	def2 := &models.StepDefinition{Handler: fn2, HandlerValue: reflect.ValueOf(fn2), Args: []interface{}{&messages.PickleStepArgument_PickleDocString{}}}
-	def3 := &models.StepDefinition{Handler: fn3, HandlerValue: reflect.ValueOf(fn3), Args: []interface{}{(*messages.PickleStepArgument_PickleTable)(nil)}}
+	def1 := &models.StepDefinition{
+		StepDefinition: formatters.StepDefinition{
+			Handler: fn1,
+		},
+		HandlerValue: reflect.ValueOf(fn1),
+		Args:         []interface{}{(*int)(nil)},
+	}
+	def2 := &models.StepDefinition{
+		StepDefinition: formatters.StepDefinition{
+			Handler: fn2,
+		},
+		HandlerValue: reflect.ValueOf(fn2),
+		Args:         []interface{}{&messages.PickleStepArgument_PickleDocString{}},
+	}
+	def3 := &models.StepDefinition{
+		StepDefinition: formatters.StepDefinition{
+			Handler: fn3,
+		},
+		HandlerValue: reflect.ValueOf(fn3),
+		Args:         []interface{}{(*messages.PickleStepArgument_PickleTable)(nil)},
+	}
 
 	if err := def1.Run(); err == nil {
 		t.Fatalf("expected conversion error, but got none")
 	}
+
 	if err := def2.Run(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+
 	if err := def3.Run(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -71,12 +97,25 @@ func TestShouldSupportOnlyByteSlice(t *testing.T) {
 	fn1 := func(a []byte) error { return nil }
 	fn2 := func(a []string) error { return nil }
 
-	def1 := &models.StepDefinition{Handler: fn1, HandlerValue: reflect.ValueOf(fn1), Args: []interface{}{"str"}}
-	def2 := &models.StepDefinition{Handler: fn2, HandlerValue: reflect.ValueOf(fn2), Args: []interface{}{[]string{}}}
+	def1 := &models.StepDefinition{
+		StepDefinition: formatters.StepDefinition{
+			Handler: fn1,
+		},
+		HandlerValue: reflect.ValueOf(fn1),
+		Args:         []interface{}{"str"},
+	}
+	def2 := &models.StepDefinition{
+		StepDefinition: formatters.StepDefinition{
+			Handler: fn2,
+		},
+		HandlerValue: reflect.ValueOf(fn2),
+		Args:         []interface{}{[]string{}},
+	}
 
 	if err := def1.Run(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+
 	if err := def2.Run(); err == nil {
 		t.Fatalf("expected conversion error, but got none")
 	}
@@ -84,7 +123,12 @@ func TestShouldSupportOnlyByteSlice(t *testing.T) {
 
 func TestUnexpectedArguments(t *testing.T) {
 	fn := func(a, b int) error { return nil }
-	def := &models.StepDefinition{Handler: fn, HandlerValue: reflect.ValueOf(fn)}
+	def := &models.StepDefinition{
+		StepDefinition: formatters.StepDefinition{
+			Handler: fn,
+		},
+		HandlerValue: reflect.ValueOf(fn),
+	}
 
 	def.Args = []interface{}{"1"}
 	if err := def.Run(); err == nil {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -31,6 +31,9 @@ const (
 	tablePickleStepResultIndexPickleStepID string = "id"
 	tablePickleStepResultIndexPickleID     string = "pickle_id"
 	tablePickleStepResultIndexStatus       string = "status"
+
+	tableStepDefintionMatch            string = "step_defintion_match"
+	tableStepDefintionMatchIndexStepID string = "id"
 )
 
 // Storage is a thread safe in-mem storage
@@ -108,6 +111,16 @@ func NewStorage() *Storage {
 						Name:    tablePickleStepResultIndexStatus,
 						Unique:  false,
 						Indexer: &memdb.IntFieldIndex{Field: "Status"},
+					},
+				},
+			},
+			tableStepDefintionMatch: {
+				Name: tableStepDefintionMatch,
+				Indexes: map[string]*memdb.IndexSchema{
+					tableStepDefintionMatchIndexStepID: {
+						Name:    tableStepDefintionMatchIndexStepID,
+						Unique:  true,
+						Indexer: &memdb.StringFieldIndex{Field: "StepID"},
 					},
 				},
 			},
@@ -249,6 +262,27 @@ func (s *Storage) MustGetFeatures() (fs []*models.Feature) {
 	}
 
 	return
+}
+
+type stepDefinitionMatch struct {
+	StepID         string
+	StepDefinition *models.StepDefinition
+}
+
+// MustInsertStepDefintionMatch will insert the matched StepDefintion for the step ID and panic on error.
+func (s *Storage) MustInsertStepDefintionMatch(stepID string, match *models.StepDefinition) {
+	d := stepDefinitionMatch{
+		StepID:         stepID,
+		StepDefinition: match,
+	}
+
+	s.mustInsert(tableStepDefintionMatch, d)
+}
+
+// MustGetStepDefintionMatch will retrieve the matched StepDefintion for the step ID and panic on error.
+func (s *Storage) MustGetStepDefintionMatch(stepID string) *models.StepDefinition {
+	v := s.mustFirst(tableStepDefintionMatch, tableStepDefintionMatchIndexStepID, stepID)
+	return v.(stepDefinitionMatch).StepDefinition
 }
 
 func (s *Storage) mustInsert(table string, obj interface{}) {

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -185,3 +185,15 @@ func Test_MustGetFeatures(t *testing.T) {
 	actual := s.MustGetFeatures()
 	assert.Equal(t, expected, actual)
 }
+
+func Test_MustGetStepDefintionMatch(t *testing.T) {
+	s := storage.NewStorage()
+
+	const stepID = "<step_id>"
+
+	expected := &models.StepDefinition{}
+	s.MustInsertStepDefintionMatch(stepID, expected)
+
+	actual := s.MustGetStepDefintionMatch(stepID)
+	assert.Equal(t, expected, actual)
+}

--- a/test_context.go
+++ b/test_context.go
@@ -5,9 +5,10 @@ import (
 	"reflect"
 	"regexp"
 
-	"github.com/cucumber/godog/internal/builder"
 	"github.com/cucumber/messages-go/v10"
 
+	"github.com/cucumber/godog/formatters"
+	"github.com/cucumber/godog/internal/builder"
 	"github.com/cucumber/godog/internal/models"
 )
 
@@ -41,7 +42,7 @@ type Steps []string
 // This structure is passed to the formatter
 // when step is matched and is either failed
 // or successful
-type StepDefinition = models.StepDefinition
+type StepDefinition = formatters.StepDefinition
 
 // DocString represents the DocString argument made to a step definition
 type DocString = messages.PickleStepArgument_PickleDocString
@@ -179,9 +180,11 @@ func (ctx *ScenarioContext) Step(expr, stepFunc interface{}) {
 		panic(fmt.Sprintf("expected handler to return only one value, but it has: %d", typ.NumOut()))
 	}
 
-	def := &StepDefinition{
-		Handler:      stepFunc,
-		Expr:         regex,
+	def := &models.StepDefinition{
+		StepDefinition: formatters.StepDefinition{
+			Handler: stepFunc,
+			Expr:    regex,
+		},
 		HandlerValue: v,
 	}
 


### PR DESCRIPTION
This change would finish the move of all the needed extra exports for custom formatters to one pkg and then concentrate the exports in the base pkg to the ones needed for using godog to execute tests.

This would mean that the base of a custom formatter would look like this:
```
package customformatter

import (
	"io"

	"github.com/cucumber/godog"
	"github.com/cucumber/godog/formatters"
	"github.com/cucumber/messages-go/v10"
)

func init() {
	formatters.Format("custom", "Custom formatter", customFormatterFunc)
}

func customFormatterFunc(suite string, out io.Writer) formatters.Formatter {
	return &customFmt{suiteName: suite, out: out}
}

type customFmt struct {
	suiteName string
	out       io.Writer
}

func (f *customFmt) TestRunStarted()                                                        {}
func (f *customFmt) Feature(*messages.GherkinDocument, string, []byte)                      {}
func (f *customFmt) Pickle(*godog.Scenario)                                                 {}
func (f *customFmt) Defined(*godog.Scenario, *godog.Step, *formatters.StepDefinition)       {}
func (f *customFmt) Passed(*godog.Scenario, *godog.Step, *formatters.StepDefinition)        {}
func (f *customFmt) Skipped(*godog.Scenario, *godog.Step, *formatters.StepDefinition)       {}
func (f *customFmt) Undefined(*godog.Scenario, *godog.Step, *formatters.StepDefinition)     {}
func (f *customFmt) Failed(*godog.Scenario, *godog.Step, *formatters.StepDefinition, error) {}
func (f *customFmt) Pending(*godog.Scenario, *godog.Step, *formatters.StepDefinition)       {}
func (f *customFmt) Summary()                                                               {}
```