### PR TITLE
make pickleStepIDs unique accross multiple paths

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -78,7 +78,7 @@ func parseFeatureDir(dir string, newIDFunc func() string) ([]*models.Feature, er
 	})
 }
 
-func parsePath(path string) ([]*models.Feature, error) {
+func parsePath(path string, newIDFunc func() string) ([]*models.Feature, error) {
 	var features []*models.Feature
 
 	path, line := ExtractFeaturePathLine(path)
@@ -87,8 +87,6 @@ func parsePath(path string) ([]*models.Feature, error) {
 	if err != nil {
 		return features, err
 	}
-
-	newIDFunc := (&messages.Incrementing{}).NewId
 
 	if fi.IsDir() {
 		return parseFeatureDir(path, newIDFunc)
@@ -119,8 +117,9 @@ func ParseFeatures(filter string, paths []string) ([]*models.Feature, error) {
 
 	featureIdxs := make(map[string]int)
 	uniqueFeatureURI := make(map[string]*models.Feature)
+	newIDFunc := (&messages.Incrementing{}).NewId
 	for _, path := range paths {
-		feats, err := parsePath(path)
+		feats, err := parsePath(path, newIDFunc)
 
 		switch {
 		case os.IsNotExist(err):

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1,6 +1,10 @@
 package parser_test
 
 import (
+	"github.com/stretchr/testify/require"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,5 +34,46 @@ func Test_FeatureFilePathParser(t *testing.T) {
 		p, ln := parser.ExtractFeaturePathLine(c.input)
 		assert.Equal(t, p, c.path)
 		assert.Equal(t, ln, c.line)
+	}
+}
+
+func Test_ParseFeatures_FromMultiplePaths(t *testing.T) {
+	const featureFileName = "godogs.feature"
+	const featureFileContents = `Feature: eat godogs
+  In order to be happy
+  As a hungry gopher
+  I need to be able to eat godogs
+
+  Scenario: Eat 5 out of 12
+    Given there are 12 godogs
+    When I eat 5
+		Then there should be 7 remaining`
+
+	baseDir := filepath.Join(os.TempDir(), t.Name(), "godogs")
+	errA := os.MkdirAll(baseDir+"/a", 0755)
+	errB := os.MkdirAll(baseDir+"/b", 0755)
+	defer os.RemoveAll(baseDir)
+
+	require.Nil(t, errA)
+	require.Nil(t, errB)
+
+	err := ioutil.WriteFile(filepath.Join(baseDir+"/a", featureFileName), []byte(featureFileContents), 0644)
+	require.Nil(t, err)
+	err = ioutil.WriteFile(filepath.Join(baseDir+"/b", featureFileName), []byte(featureFileContents), 0644)
+	require.Nil(t, err)
+
+	features, err := parser.ParseFeatures("", []string{baseDir + "/a", baseDir + "/b"})
+	assert.Nil(t, err)
+	assert.Len(t, features, 2)
+
+	pickleIDs := map[string]bool{}
+	for _, f := range features {
+		for _, p := range f.Pickles {
+			if pickleIDs[p.Id] {
+				assert.Failf(t, "found duplicate pickle ID", "Pickle ID %s was already used", p.Id)
+			}
+
+			pickleIDs[p.Id] = true
+		}
 	}
 }

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1,13 +1,13 @@
 package parser_test
 
 import (
-	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cucumber/godog/internal/parser"
 )


### PR DESCRIPTION
Ran into trouble with pickleStepID not being unique when having the feature files on multiple paths.

In the failing scenario we have a bunch of features distributed along multiple paths.
I experienced a nil pointer dereference in the pretty printer when executing a scenario outline pickle.
The pickleStep received from `pickleStep = f.storage.MustGetPickleStep(result.PickleStepID)` was originating from a different feature from a different path