### PR TITLE
Added public logic for pre-parsing features

### DIFF
--- a/internal/flags/options.go
+++ b/internal/flags/options.go
@@ -2,6 +2,8 @@ package flags
 
 import (
 	"io"
+
+	"github.com/cucumber/godog/internal/models"
 )
 
 // Options are suite run options
@@ -51,8 +53,11 @@ type Options struct {
 	// Concurrency rate, not all formatters accepts this
 	Concurrency int
 
-	// All feature file paths
+	// All feature file paths. Cannot be used with Options.Features
 	Paths []string
+
+	// Parsed feature objects. Overrides Options.Paths
+	Features []*models.Feature
 
 	// Where it should print formatter output
 	Output io.Writer

--- a/parser.go
+++ b/parser.go
@@ -1,0 +1,14 @@
+package godog
+
+import (
+	"github.com/cucumber/godog/internal/models"
+	"github.com/cucumber/godog/internal/parser"
+)
+
+// ParseFeatures allows users to parse their feature files to in-memory objects
+func ParseFeatures(filter string, paths []string) ([]*Feature, error) {
+	return parser.ParseFeatures(filter, paths)
+}
+
+// Feature is an exported version of models.Feature
+type Feature = models.Feature

--- a/run.go
+++ b/run.go
@@ -200,9 +200,13 @@ func runWithOptions(suiteName string, runner runner, opt Options) int {
 	runner.fmt = formatter(suiteName, output)
 
 	var err error
-	if runner.features, err = parser.ParseFeatures(opt.Tags, opt.Paths); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		return exitOptionError
+	if len(opt.Features) > 0 {
+		runner.features = opt.Features
+	} else {
+		if runner.features, err = parser.ParseFeatures(opt.Tags, opt.Paths); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return exitOptionError
+		}
 	}
 
 	runner.storage = storage.NewStorage()

--- a/run_test.go
+++ b/run_test.go
@@ -273,14 +273,14 @@ func Test_RandomizeRun_WithStaticSeed(t *testing.T) {
 	expectedStatus, expectedOutput := testRun(t,
 		fmtOutputScenarioInitializer,
 		formatter, noConcurrencyFlag,
-		noRandomFlag, []string{featurePath},
+		noRandomFlag, []string{featurePath}, nil,
 	)
 
 	const staticSeed int64 = 1
 	actualStatus, actualOutput := testRun(t,
 		fmtOutputScenarioInitializer,
 		formatter, noConcurrencyFlag,
-		staticSeed, []string{featurePath},
+		staticSeed, []string{featurePath}, nil,
 	)
 
 	actualSeed := parseSeed(actualOutput)
@@ -312,7 +312,7 @@ func Test_RandomizeRun_RerunWithSeed(t *testing.T) {
 	expectedStatus, expectedOutput := testRun(t,
 		fmtOutputScenarioInitializer,
 		formatter, noConcurrencyFlag,
-		createRandomSeedFlag, []string{featurePath},
+		createRandomSeedFlag, []string{featurePath}, nil,
 	)
 
 	expectedSeed := parseSeed(expectedOutput)
@@ -321,7 +321,7 @@ func Test_RandomizeRun_RerunWithSeed(t *testing.T) {
 	actualStatus, actualOutput := testRun(t,
 		fmtOutputScenarioInitializer,
 		formatter, noConcurrencyFlag,
-		expectedSeed, []string{featurePath},
+		expectedSeed, []string{featurePath}, nil,
 	)
 
 	actualSeed := parseSeed(actualOutput)
@@ -347,7 +347,7 @@ func Test_FormatOutputRun(t *testing.T) {
 	expectedStatus, expectedOutput := testRun(t,
 		fmtOutputScenarioInitializer,
 		formatter, noConcurrencyFlag,
-		noRandomFlag, []string{featurePath},
+		noRandomFlag, []string{featurePath}, nil,
 	)
 
 	dir := filepath.Join(os.TempDir(), t.Name())
@@ -361,7 +361,7 @@ func Test_FormatOutputRun(t *testing.T) {
 	actualStatus, actualOutput := testRun(t,
 		fmtOutputScenarioInitializer,
 		formatter+":"+file, noConcurrencyFlag,
-		noRandomFlag, []string{featurePath},
+		noRandomFlag, []string{featurePath}, nil,
 	)
 
 	result, err := ioutil.ReadFile(file)
@@ -394,7 +394,7 @@ func Test_FormatOutputRun_Error(t *testing.T) {
 	actualStatus, actualOutput := testRun(t,
 		fmtOutputScenarioInitializer,
 		formatter+":"+file, noConcurrencyFlag,
-		noRandomFlag, []string{featurePath},
+		noRandomFlag, []string{featurePath}, nil,
 	)
 
 	assert.Equal(t, expectedStatus, actualStatus)
@@ -424,7 +424,17 @@ func Test_AllFeaturesRun(t *testing.T) {
 	actualStatus, actualOutput := testRun(t,
 		InitializeScenario,
 		format, concurrency,
-		noRandomFlag, []string{"features"},
+		noRandomFlag, []string{"features"}, nil,
+	)
+
+	assert.Equal(t, exitSuccess, actualStatus)
+	assert.Equal(t, expected, actualOutput)
+
+	features, _ := ParseFeatures("", []string{"features"})
+	actualStatus, actualOutput = testRun(t,
+		InitializeScenario,
+		format, concurrency,
+		noRandomFlag, nil, features,
 	)
 
 	assert.Equal(t, exitSuccess, actualStatus)
@@ -460,12 +470,12 @@ func Test_FormatterConcurrencyRun(t *testing.T) {
 				expectedStatus, expectedOutput := testRun(t,
 					fmtOutputScenarioInitializer,
 					formatter, noConcurrency,
-					noRandomFlag, featurePaths,
+					noRandomFlag, featurePaths, nil,
 				)
 				actualStatus, actualOutput := testRun(t,
 					fmtOutputScenarioInitializer,
 					formatter, concurrency,
-					noRandomFlag, featurePaths,
+					noRandomFlag, featurePaths, nil,
 				)
 
 				assert.Equal(t, expectedStatus, actualStatus)
@@ -482,6 +492,7 @@ func testRun(
 	concurrency int,
 	randomSeed int64,
 	featurePaths []string,
+	features []*models.Feature,
 ) (int, string) {
 	output := new(bytes.Buffer)
 
@@ -491,6 +502,7 @@ func testRun(
 		Paths:       featurePaths,
 		Concurrency: concurrency,
 		Randomize:   randomSeed,
+		Features:    features,
 		Output:      output,
 	}
 


### PR DESCRIPTION
This PR is to resolve issue #328.

Our project uses Godog to package a series of tests into a single binary that our users can execute in their own pipelines to validate their cloud infrastructure security compliance. 

Currently we have been using Pkger to store the feature files into the binary, write the feature files to a temporary directory that Godog can read, and then delete the files at the end of the runtime. This is functional, but not desirable.

The changes proposed in this PR will allow Godog users (such as our project) to pre-parse their feature files, instead of relying on I/O.

The following changes are present:
1. Expose the parser for public usage
2. Extend `flags.Options` to receive parsed feature objects
3. Add a condition to `run.go` that will use the parsed features instead of `Paths`
4. Extended existing tests to ensure "Features" are run identically to "Paths"