### PR TITLE
remove renamed imports of pflag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,13 +346,12 @@ The following example binds **godog** flags with specified prefix `godog` in ord
 package main
 
 import (
-	"flag" // godog v0.10.0 and earlier
 	"os"
 	"testing"
 
 	"github.com/cucumber/godog"
 	"github.com/cucumber/godog/colors"
-	flag "github.com/spf13/pflag" // godog v0.11.0 (latest)
+	"github.com/spf13/pflag" // godog v0.11.0 (latest)
 )
 
 var opts = godog.Options{
@@ -361,13 +360,13 @@ var opts = godog.Options{
 }
 
 func init() {
-	godog.BindFlags("godog.", flag.CommandLine, &opts) // godog v0.10.0 and earlier
+	godog.BindFlags("godog.", pflag.CommandLine, &opts) // godog v0.10.0 and earlier
 	godog.BindCommandLineFlags("godog.", &opts)        // godog v0.11.0 (latest)
 }
 
 func TestMain(m *testing.M) {
-	flag.Parse()
-	opts.Paths = flag.Args()
+	pflag.Parse()
+	opts.Paths = pflag.Args()
 
 	status := godog.TestSuite{
 		Name: "godogs",

--- a/_examples/assert-godogs/godogs_test.go
+++ b/_examples/assert-godogs/godogs_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/cucumber/godog"
 	"github.com/cucumber/godog/colors"
-	flag "github.com/spf13/pflag"
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,8 +18,8 @@ func init() {
 }
 
 func TestMain(m *testing.M) {
-	flag.Parse()
-	opts.Paths = flag.Args()
+	pflag.Parse()
+	opts.Paths = pflag.Args()
 
 	status := godog.TestSuite{
 		Name:                "godogs",

--- a/_examples/godogs/godogs_test.go
+++ b/_examples/godogs/godogs_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/cucumber/godog"
 	"github.com/cucumber/godog/colors"
-	flag "github.com/spf13/pflag"
+	"github.com/spf13/pflag"
 )
 
 var opts = godog.Options{Output: colors.Colored(os.Stdout)}
@@ -17,8 +17,8 @@ func init() {
 }
 
 func TestMain(m *testing.M) {
-	flag.Parse()
-	opts.Paths = flag.Args()
+	pflag.Parse()
+	opts.Paths = pflag.Args()
 
 	status := godog.TestSuite{
 		Name:                 "godogs",

--- a/cmd/godog/internal/cmd_root.go
+++ b/cmd/godog/internal/cmd_root.go
@@ -2,7 +2,7 @@ package internal
 
 import (
 	"github.com/spf13/cobra"
-	flag "github.com/spf13/pflag"
+	"github.com/spf13/pflag"
 
 	"github.com/cucumber/godog/internal/flags"
 )
@@ -40,7 +40,7 @@ and contain buildable go source.`,
 	return rootCmd
 }
 
-func bindRootCmdFlags(flagSet *flag.FlagSet) {
+func bindRootCmdFlags(flagSet *pflag.FlagSet) {
 	flagSet.StringVarP(&output, "output", "o", "", "compiles the test runner to the named file")
 	flagSet.BoolVar(&version, "version", false, "show current version")
 

--- a/release-notes/v0.11.0.md
+++ b/release-notes/v0.11.0.md
@@ -65,7 +65,7 @@ import (
 
 	"github.com/cucumber/godog"
 	"github.com/cucumber/godog/colors"
-	flag "github.com/spf13/pflag"
+	"github.com/spf13/pflag"
 )
 
 var opts = godog.Options{Output: colors.Colored(os.Stdout)}
@@ -75,8 +75,8 @@ func init() {
 }
 
 func TestMain(m *testing.M) {
-	flag.Parse()
-	opts.Paths = flag.Args()
+	pflag.Parse()
+	opts.Paths = pflag.Args()
   
   // ...
 ```


### PR DESCRIPTION
This was causing way to much investigating in order for me to find
That I've only copied parts of the examples resulting in "flag".Parse
instead of pflag.Parse()