### PR TITLE
Fix step definition output for Data Tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 ### Removed
 
 ### Fixed
+* Incorrect step definition output for Data Tables ([411](https://github.com/cucumber/godog/pull/411) - [karfrank])
 
 ## [v0.11.0]
 

--- a/internal/models/stepdef.go
+++ b/internal/models/stepdef.go
@@ -145,7 +145,7 @@ func (sd *StepDefinition) Run() interface{} {
 					break
 				}
 
-				return fmt.Errorf(`%w %d: "%v" of type "%T" to *messages.PickleStepArgument_PickleTable`, ErrCannotConvert, i, arg, arg)
+				return fmt.Errorf(`%w %d: "%v" of type "%T" to *messages.PickleTable`, ErrCannotConvert, i, arg, arg)
 			default:
 				return fmt.Errorf("%w: the argument %d type %T is not supported %s", ErrUnsupportedArgumentType, i, arg, param.Elem().String())
 			}


### PR DESCRIPTION
# Description

This fixes incorrect step definition output for Data Tables. 

# Motivation & context

The current code doesn't generate a correct function for Data Tables. The
`PickleStepArgument_PickleTable` type does not exist in the current `messages-go`  package.

For example:
```
Feature: Test Data Table  
                                                                                                                                                                                                                                                                                                                                                                                                                                                            
  Scenario: Data table                                                                                                                                                                                                                         
    Given there is data:                                                                                                                                                                                                                       
      | A |                                                                                                                                                                                                                                    
      | B |                                                                                                                                                                                                                                    
      | C |                                                                                                                                                                                                                                    
    When I run the scenario                                                                                                                                                                                                                    
    Then Godog should provide show the correct step definition
```

Generates the following output:

```
Feature: Test Data Table

  Scenario: Data table                                         # features/test.feature:3
    Given there is data:
      | A |
      | B |
      | C |
    When I run the scenario
    Then Godog should provide show the correct step definition

1 scenarios (1 undefined)
3 steps (3 undefined)
474.442µs

You can implement step definitions for undefined steps with these snippets:

func godogShouldProvideShowTheCorrectStepDefinition() error {
        return godog.ErrPending
}

func iRunTheScenario() error {
        return godog.ErrPending
}

func thereIsData(arg1 *messages.PickleStepArgument_PickleTable) error {
        return godog.ErrPending
}

func InitializeScenario(ctx *godog.ScenarioContext) {
        ctx.Step(`^Godog should provide show the correct step definition$`, godogShouldProvideShowTheCorrectStepDefinition)
        ctx.Step(`^I run the scenario$`, iRunTheScenario)
        ctx.Step(`^there is data:$`, thereIsData)
}
```

This output seems to be wrong:

```
func thereIsData(arg1 *messages.PickleStepArgument_PickleTable) error {
        return godog.ErrPending
}
```
There is no `PickleStepArgument_PickleTable` type defined in https://github.com/cucumber/messages-go/blob/v16.0.1/messages.go, so running the generated code results in the following error:

```
godog
failed to compile tested package: /playground, reason: exit status 2, output: go: finding module for package github.com/cucumber/messages-go/v16                                           
go: found github.com/cucumber/messages-go/v16 in github.com/cucumber/messages-go/v16 v16.0.1
WORK=/tmp/go-build855275816
# playground [playground.test]
./demo_test.go:16:24: undefined: "github.com/cucumber/messages-go/v16".PickleStepArgument_PickleTable
```
The update in this PR changes the step definition output to:

```
func thereIsData(arg1 *godog.Table) error {
        return godog.ErrPending
}
```
which works as expected. 

I hope this all makes sense and is helpful. Please let me know if there are any issues with this PR (it's my first contribution to this project). Thank you!

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Update required of cucumber.io/docs

I couldn't find anything about this in the docs.

# Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](../CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
