### PR TITLE
Reduce dependency when implementing custom formatter with local alias

### DIFF
--- a/test_context.go
+++ b/test_context.go
@@ -13,6 +13,9 @@ import (
 	"github.com/cucumber/godog/internal/models"
 )
 
+// Feature represents gherkin document.
+type Feature = messages.GherkinDocument
+
 // Scenario represents the executed scenario
 type Scenario = messages.Pickle
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

This PR adds a local type alias for `messages.GherkinDocument` to make formatter interface independent of `messages` import path.

# Motivation & context

We're going too change import path for messages some time soon (#389), that would be a breaking change for custom formatters.
With local type alias it would be possible to implement formatter that have a chance to avoid breaking change.

## Type of change

<!--- Delete any options that are not relevant -->

- Refactoring/debt (improvement to code design or tooling without changing behaviour)

## Note to other contributors

No note.

## Update required of cucumber.io/docs

No update.

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](../CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
