### PR TITLE
Add go1.17 to CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,10 @@ executors:
       - image: circleci/golang:1.15.5
   exec_go_1_16:
     docker:
-      - image: cimg/go:1.16.5
+      - image: cimg/go:1.16.7
+  exec_go_1_17:
+    docker:
+      - image: cimg/go:1.17.0
 
 commands:
   fmt:
@@ -81,6 +84,11 @@ jobs:
     executor: exec_go_1_16
     steps:
       - all
+  go1_17:
+    working_directory: /home/circleci/go/src/github.com/cucumber/godog
+    executor: exec_go_1_17
+    steps:
+      - all
 
 workflows:
   version: 2
@@ -90,3 +98,4 @@ workflows:
       - go1_14
       - go1_15
       - go1_16
+      - go1_17

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ executors:
       - image: cimg/go:1.16.7
   exec_go_1_17:
     docker:
-      - image: cimg/go:1.17.0
+      - image: cimg/go:1.17
 
 commands:
   fmt:

--- a/colors/ansi_others.go
+++ b/colors/ansi_others.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !windows
 // +build !windows
 
 package colors

--- a/colors/ansi_windows.go
+++ b/colors/ansi_windows.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build windows
 // +build windows
 
 package colors

--- a/internal/builder/builder_go112_test.go
+++ b/internal/builder/builder_go112_test.go
@@ -1,5 +1,5 @@
-// +build go1.12
-// +build !go1.13
+//go:build go1.12 && !go1.13
+// +build go1.12,!go1.13
 
 package builder_test
 

--- a/internal/builder/builder_go113_test.go
+++ b/internal/builder/builder_go113_test.go
@@ -1,3 +1,4 @@
+//go:build go1.13
 // +build go1.13
 
 package builder_test

--- a/release-notes/v0.12.0.md
+++ b/release-notes/v0.12.0.md
@@ -108,9 +108,9 @@ You can now use `string` instead of `*godog.DocString` in declaration.
 
 `godog.TestSuite` now can `RetrieveFeatures() ([]*models.Feature, error)` to expose parsed features to the user.
 
-### Added official support for go1.16
+### Added official support for go1.16 and go1.17
 
-With the introduction of go1.16, go1.16 is now officially supported.
+With the introduction of go1.17, go1.17 and go1.16 are now officially supported.
 
 ### Running scenarios as subtests of *testing.T
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

This PR adds go1.17 to CI.

# Motivation & context

Go 1.17 is the currently latest version and godog should support it.

## Type of change

- Refactoring/debt (improvement to code design or tooling without changing behaviour)


## Note to other contributors

No note.

## Update required of cucumber.io/docs

No update.

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](../CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
