### PR TITLE
Run before step hooks before matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- Unintended change of behavior in before step hook ([424](https://github.com/cucumber/godog/pull/424) - [nhatthm])
+
 ## [v0.12.0]
 
 ### Added
@@ -190,7 +196,8 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 <!-- Releases -->
 
-[unreleased]: https://github.com/cucumber/godog/compare/v0.11.0...main
+[unreleased]: https://github.com/cucumber/godog/compare/v0.12.0...main
+[v0.12.0]: https://github.com/cucumber/godog/compare/v0.11.0...v0.12.0
 [v0.11.0]: https://github.com/cucumber/godog/compare/v0.10.0...v0.11.0
 [v0.10.0]: https://github.com/cucumber/godog/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/cucumber/godog/compare/v0.8.1...v0.9.0
@@ -215,3 +222,4 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 [chirino]: https://github.com/chirino
 [radtriste]: https://github.com/radtriste
 [karfrank]: https://github.com/karfrank
+[nhatthm]: https://github.com/nhatthm

--- a/suite.go
+++ b/suite.go
@@ -134,12 +134,12 @@ func (s *suite) runStep(ctx context.Context, pickle *Scenario, step *Step, prevS
 		ctx, err = s.runBeforeScenarioHooks(ctx, pickle)
 	}
 
+	// run before step handlers
+	ctx, err = s.runBeforeStepHooks(ctx, step, err)
+
 	match = s.matchStep(step)
 	s.storage.MustInsertStepDefintionMatch(step.AstNodeIds[0], match)
 	s.fmt.Defined(pickle, step, match.GetInternalStepDefinition())
-
-	// run before step handlers
-	ctx, err = s.runBeforeStepHooks(ctx, step, err)
 
 	if err != nil {
 		sr = models.NewStepResult(pickle.Id, step.Id, match)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Original PR: https://github.com/cucumber/godog/pull/424.

There is an breaking change in `v0.12.0`, the `beforeStep` hooks are executed after `s.matchStep(step)`. Because of that, any changes in the `Step` won't be applied and taken into consideration in `matchStep()`

https://github.com/cucumber/godog/blob/afaebf26c1bc38e160c48cf921e65e52307fa3bd/suite.go#L137-L142

This behavior is newly introduced in `v0.12.0`, in the previous version, the hooks are executed before `matchStep()`

https://github.com/cucumber/godog/blob/2b426f89696bd14865efdce2f001b75be9ae9efb/suite.go#L52-L59

I see this (breaking) change is _unnecessary_ and would like to bring back the old behavior.

I don't know if we should consider this as a bug or not.

# Motivation & context

I have some logic to dynamically replace the value in the step using `beforeStep` hook. For a (stupid) example

```gherkin
    Scenario: Env var is replaced
        Given env var FOOBAR is replaced in step text: $FOOBAR
```

And the step handler will be like

```go
func assertFoobar(v string) {
	// v should be replaced beforehand by the hook.
	assert.NotEqual(t, "$FOOBAR", v)
}
```

In `v0.12.0`, `v` is still `$FOOBAR` because the change is too late, `matchStep` is executed with the original step definition

## Type of change

- Refactoring/debt (improvement to code design or tooling without changing behaviour)
- Bug fix (non-breaking change which fixes an issue)

## Note to other contributors

n/a
<!--_If your change may impact future contributors, explain it here, and remember to update README.md and CONTRIBUTING.md accordingly._-->

## Update required of cucumber.io/docs

n/a
<!--_If the [Cucumber documentation](https://cucumber.io/docs/) will require an update,
submit an issue or ideally a pull request to [cucumber/docs](https://github.com/cucumber/docs/) and
reference it here._

_e.g. "Ref: cucumber/docs/pull/#99"_-->

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](../CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
