### PR TITLE
Use common packages from monorepo

### DIFF
--- a/_examples/custom-formatter/go.sum
+++ b/_examples/custom-formatter/go.sum
@@ -32,11 +32,11 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/cucumber/gherkin-go/v19 v19.0.3 h1:mMSKu1077ffLbTJULUfM5HPokgeBcIGboyeNUof1MdE=
-github.com/cucumber/gherkin-go/v19 v19.0.3/go.mod h1:jY/NP6jUtRSArQQJ5h1FXOUgk5fZK24qtE7vKi776Vw=
-github.com/cucumber/messages-go/v16 v16.0.0/go.mod h1:EJcyR5Mm5ZuDsKJnT2N9KRnBK30BGjtYotDKpwQ0v6g=
-github.com/cucumber/messages-go/v16 v16.0.1 h1:fvkpwsLgnIm0qugftrw2YwNlio+ABe2Iu94Ap8GMYIY=
-github.com/cucumber/messages-go/v16 v16.0.1/go.mod h1:EJcyR5Mm5ZuDsKJnT2N9KRnBK30BGjtYotDKpwQ0v6g=
+github.com/cucumber/common/gherkin/go/v20 v20.0.1 h1:RALUueX0deunBTeiulYYIkvHVFGo+9Ys4XOnSvWURvA=
+github.com/cucumber/common/gherkin/go/v20 v20.0.1/go.mod h1:bztLuweNsq76hZmo3dzXOK1uaB9CHsmOuPmF3qQbrU8=
+github.com/cucumber/common/messages/go/v17 v17.0.0/go.mod h1:bpGxb57tDE385Rb2EohgUadLkAbhoC4IyCFi89u/JQI=
+github.com/cucumber/common/messages/go/v17 v17.0.1 h1:zHQ2Zq4GVxbb8OAaVo07+BoN/QBodGvS4PbvsE2L9SU=
+github.com/cucumber/common/messages/go/v17 v17.0.1/go.mod h1:bpGxb57tDE385Rb2EohgUadLkAbhoC4IyCFi89u/JQI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/formatters/fmt.go
+++ b/formatters/fmt.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"regexp"
 
-	"github.com/cucumber/messages-go/v16"
+	"github.com/cucumber/common/messages/go/v17"
 )
 
 type registeredFormatter struct {

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/cucumber/godog
 go 1.13
 
 require (
-	github.com/cucumber/gherkin-go/v19 v19.0.3
-	github.com/cucumber/messages-go/v16 v16.0.1
+	github.com/cucumber/common/gherkin/go/v20 v20.0.1
+	github.com/cucumber/common/messages/go/v17 v17.0.1
 	github.com/hashicorp/go-memdb v1.3.0
 	github.com/hashicorp/go-uuid v1.0.2 // indirect
 	github.com/smartystreets/goconvey v1.6.4

--- a/go.sum
+++ b/go.sum
@@ -31,11 +31,11 @@ github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
-github.com/cucumber/gherkin-go/v19 v19.0.3 h1:mMSKu1077ffLbTJULUfM5HPokgeBcIGboyeNUof1MdE=
-github.com/cucumber/gherkin-go/v19 v19.0.3/go.mod h1:jY/NP6jUtRSArQQJ5h1FXOUgk5fZK24qtE7vKi776Vw=
-github.com/cucumber/messages-go/v16 v16.0.0/go.mod h1:EJcyR5Mm5ZuDsKJnT2N9KRnBK30BGjtYotDKpwQ0v6g=
-github.com/cucumber/messages-go/v16 v16.0.1 h1:fvkpwsLgnIm0qugftrw2YwNlio+ABe2Iu94Ap8GMYIY=
-github.com/cucumber/messages-go/v16 v16.0.1/go.mod h1:EJcyR5Mm5ZuDsKJnT2N9KRnBK30BGjtYotDKpwQ0v6g=
+github.com/cucumber/common/gherkin/go/v20 v20.0.1 h1:RALUueX0deunBTeiulYYIkvHVFGo+9Ys4XOnSvWURvA=
+github.com/cucumber/common/gherkin/go/v20 v20.0.1/go.mod h1:bztLuweNsq76hZmo3dzXOK1uaB9CHsmOuPmF3qQbrU8=
+github.com/cucumber/common/messages/go/v17 v17.0.0/go.mod h1:bpGxb57tDE385Rb2EohgUadLkAbhoC4IyCFi89u/JQI=
+github.com/cucumber/common/messages/go/v17 v17.0.1 h1:zHQ2Zq4GVxbb8OAaVo07+BoN/QBodGvS4PbvsE2L9SU=
+github.com/cucumber/common/messages/go/v17 v17.0.1/go.mod h1:bpGxb57tDE385Rb2EohgUadLkAbhoC4IyCFi89u/JQI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/formatters/fmt.go
+++ b/internal/formatters/fmt.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cucumber/messages-go/v16"
+	"github.com/cucumber/common/messages/go/v17"
 
 	"github.com/cucumber/godog/colors"
 	"github.com/cucumber/godog/internal/models"

--- a/internal/formatters/fmt_base.go
+++ b/internal/formatters/fmt_base.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"unicode"
 
-	"github.com/cucumber/messages-go/v16"
+	"github.com/cucumber/common/messages/go/v17"
 
 	"github.com/cucumber/godog/colors"
 	"github.com/cucumber/godog/formatters"

--- a/internal/formatters/fmt_cucumber.go
+++ b/internal/formatters/fmt_cucumber.go
@@ -18,7 +18,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/cucumber/messages-go/v16"
+	"github.com/cucumber/common/messages/go/v17"
 
 	"github.com/cucumber/godog/formatters"
 	"github.com/cucumber/godog/internal/models"

--- a/internal/formatters/fmt_events.go
+++ b/internal/formatters/fmt_events.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/cucumber/messages-go/v16"
+	"github.com/cucumber/common/messages/go/v17"
 
 	"github.com/cucumber/godog/formatters"
 	"github.com/cucumber/godog/internal/utils"

--- a/internal/formatters/fmt_multi.go
+++ b/internal/formatters/fmt_multi.go
@@ -3,9 +3,9 @@ package formatters
 import (
 	"io"
 
+	"github.com/cucumber/common/messages/go/v17"
 	"github.com/cucumber/godog/formatters"
 	"github.com/cucumber/godog/internal/storage"
-	"github.com/cucumber/messages-go/v16"
 )
 
 // MultiFormatter passes test progress to multiple formatters.

--- a/internal/formatters/fmt_pretty.go
+++ b/internal/formatters/fmt_pretty.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/cucumber/messages-go/v16"
+	"github.com/cucumber/common/messages/go/v17"
 
 	"github.com/cucumber/godog/colors"
 	"github.com/cucumber/godog/formatters"

--- a/internal/formatters/fmt_progress.go
+++ b/internal/formatters/fmt_progress.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/cucumber/messages-go/v16"
+	"github.com/cucumber/common/messages/go/v17"
 
 	"github.com/cucumber/godog/formatters"
 )

--- a/internal/formatters/undefined_snippets_gen.go
+++ b/internal/formatters/undefined_snippets_gen.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/cucumber/messages-go/v16"
+	"github.com/cucumber/common/messages/go/v17"
 )
 
 // some snippet formatting regexps

--- a/internal/models/feature.go
+++ b/internal/models/feature.go
@@ -1,7 +1,7 @@
 package models
 
 import (
-	"github.com/cucumber/messages-go/v16"
+	"github.com/cucumber/common/messages/go/v17"
 )
 
 // Feature is an internal object to group together

--- a/internal/models/stepdef.go
+++ b/internal/models/stepdef.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"strconv"
 
-	"github.com/cucumber/messages-go/v16"
+	"github.com/cucumber/common/messages/go/v17"
 
 	"github.com/cucumber/godog/formatters"
 )

--- a/internal/models/stepdef_test.go
+++ b/internal/models/stepdef_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cucumber/messages-go/v16"
+	"github.com/cucumber/common/messages/go/v17"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/cucumber/godog"

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -10,8 +10,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cucumber/gherkin-go/v19"
-	"github.com/cucumber/messages-go/v16"
+	"github.com/cucumber/common/gherkin/go/v20"
+	"github.com/cucumber/common/messages/go/v17"
 
 	"github.com/cucumber/godog/internal/models"
 	"github.com/cucumber/godog/internal/tags"

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/cucumber/messages-go/v16"
+	"github.com/cucumber/common/messages/go/v17"
 	"github.com/hashicorp/go-memdb"
 
 	"github.com/cucumber/godog/internal/models"

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cucumber/messages-go/v16"
+	"github.com/cucumber/common/messages/go/v17"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/cucumber/godog/internal/models"

--- a/internal/tags/tag_filter.go
+++ b/internal/tags/tag_filter.go
@@ -3,7 +3,7 @@ package tags
 import (
 	"strings"
 
-	"github.com/cucumber/messages-go/v16"
+	"github.com/cucumber/common/messages/go/v17"
 )
 
 // ApplyTagFilter will apply a filter string on the

--- a/internal/tags/tag_filter_test.go
+++ b/internal/tags/tag_filter_test.go
@@ -3,7 +3,7 @@ package tags_test
 import (
 	"testing"
 
-	"github.com/cucumber/messages-go/v16"
+	"github.com/cucumber/common/messages/go/v17"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/cucumber/godog/internal/tags"

--- a/internal/testutils/utils.go
+++ b/internal/testutils/utils.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cucumber/gherkin-go/v19"
-	"github.com/cucumber/messages-go/v16"
+	"github.com/cucumber/common/gherkin/go/v20"
+	"github.com/cucumber/common/messages/go/v17"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cucumber/godog/internal/models"

--- a/run.go
+++ b/run.go
@@ -14,7 +14,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/cucumber/messages-go/v16"
+	"github.com/cucumber/common/messages/go/v17"
 
 	"github.com/cucumber/godog/colors"
 	"github.com/cucumber/godog/formatters"

--- a/run_progress_test.go
+++ b/run_progress_test.go
@@ -2,11 +2,11 @@ package godog
 
 import (
 	"bytes"
-	"github.com/cucumber/messages-go/v16"
+	"github.com/cucumber/common/messages/go/v17"
 	"strings"
 	"testing"
 
-	"github.com/cucumber/gherkin-go/v19"
+	"github.com/cucumber/common/gherkin/go/v20"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/run_test.go
+++ b/run_test.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cucumber/gherkin-go/v19"
-	"github.com/cucumber/messages-go/v16"
+	"github.com/cucumber/common/gherkin/go/v20"
+	"github.com/cucumber/common/messages/go/v17"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/suite.go
+++ b/suite.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cucumber/messages-go/v16"
+	"github.com/cucumber/common/messages/go/v17"
 
 	"github.com/cucumber/godog/formatters"
 	"github.com/cucumber/godog/internal/models"

--- a/suite_context_test.go
+++ b/suite_context_test.go
@@ -12,8 +12,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cucumber/gherkin-go/v19"
-	"github.com/cucumber/messages-go/v16"
+	"github.com/cucumber/common/gherkin/go/v20"
+	"github.com/cucumber/common/messages/go/v17"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/cucumber/godog/colors"

--- a/test_context.go
+++ b/test_context.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"regexp"
 
-	"github.com/cucumber/messages-go/v16"
+	"github.com/cucumber/common/messages/go/v17"
 
 	"github.com/cucumber/godog/formatters"
 	"github.com/cucumber/godog/internal/builder"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

This PR changes imports of `messages` and `gherkin` to use common monorepo.

# Motivation & context

Pros:
* A small change to `godog`
* Code coverage and lint are not affected

Cons:
* Runtime double dependency on a large repo (one copy for `gherkin/go/v20` and one for `messages/go/v17`)
* Every further change of imports (e.g. to `messages/go/v18`) is technically a  breaking change for `godog` as end-users may depend on messages directly while implementing advanced step definitions.

Runtime dependency on a monorepo seems like not a big deal, for example in GitHub Actions those packages are retrieved in 1-2 seconds.

Resolves #389.

## Type of change

<!--- Delete any options that are not relevant -->

- Refactoring/debt (improvement to code design or tooling without changing behaviour)
- Breaking change (will cause existing functionality to not
  work as expected)

## Note to other contributors

No notes.

## Update required of cucumber.io/docs

No update.

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](../CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
