### PR TITLE
Fix compilation for non-modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 ---
 
+## [v0.12.2]
+
+### Fixed
+
+- Error in `go mod tidy` with `GO111MODULE=off` ([436]((https://github.com/cucumber/godog/pull/436) - [vearutop])
+
 ## [v0.12.1]
 
 ### Fixed
@@ -196,6 +202,7 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 <!-- Releases -->
 
+[v0.12.2]: https://github.com/cucumber/godog/compare/v0.12.1...v0.12.2
 [v0.12.1]: https://github.com/cucumber/godog/compare/v0.12.0...v0.12.1
 [v0.12.0]: https://github.com/cucumber/godog/compare/v0.11.0...v0.12.0
 [v0.11.0]: https://github.com/cucumber/godog/compare/v0.10.0...v0.11.0

--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -127,9 +127,11 @@ func Build(bin string) error {
 	// we also print back the temp WORK directory
 	// go has built. We will reuse it for our suite workdir.
 	temp := fmt.Sprintf(filepath.Join("%s", "temp-%d.test"), os.TempDir(), time.Now().UnixNano())
-	modTidyOutput, err := exec.Command("go", "mod", "tidy").CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to tidy modules in tested package: %s, reason: %v, output: %s", abs, err, string(modTidyOutput))
+	if os.Getenv("GO111MODULE") != "off" {
+		modTidyOutput, err := exec.Command("go", "mod", "tidy").CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("failed to tidy modules in tested package: %s, reason: %v, output: %s", abs, err, string(modTidyOutput))
+		}
 	}
 	testOutput, err := exec.Command("go", "test", "-c", "-work", "-o", temp).CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

This PR adds a check for `GO111MODULE` env var to avoid `go mod tidy` in non-module mode.

# Motivation & context

Relates to #405.

## Type of change

<!--- Delete any options that are not relevant -->

- Bug fix (non-breaking change which fixes an issue)

## Note to other contributors

No note.

## Update required of cucumber.io/docs

No update.

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](../CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
