### PR TITLE
Friendlier contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,6 @@ Once that's done, try running the tests:
 
 If everything passes, you're ready to hack!
 
-[install go](https://golang.org/doc/install)
+[install go]: https://golang.org/doc/install
 [community Slack]: https://cucumber.io/community#slack
 [raise an issue]: https://github.com/cucumber/godog/issues/new/choose

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,11 +11,7 @@ You can chat with us in the [#committers-go](https://cucumberbdd.slack.com/archi
 
 ## Setup
 
-To get your development environment set up, you'll need to [install Go].
-
-Now install golint:
-
-    go install golang.org/x/lint/golint@latest
+To get your development environment set up, you'll need to [install Go]. We're currently using version 1.17 for development.
 
 Once that's done, try running the tests:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Now install golint:
 
 Once that's done, try running the tests:
 
-    make
+    make test
 
 If everything passes, you're ready to hack!
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,24 @@
-## About to contribute?
+# Welcome 💖
 
-We appreciate that. But before you do, please learn our basic rules:
+Before anything else, thank you for taking some of your precious time to help this project move forward. ❤️
 
-* Do you have a feature request? Then don't expect it to be implemented unless
-  you or someone else sends a [pull request](https://help.github.com/articles/using-pull-requests).
-* We love [pull requests](https://help.github.com/articles/using-pull-requests),
-  but if you don't have a test to go with it we probably won't merge it.
-* Before making significant contribution consider discussing the outline of
-  your solution first. This may avoid a duplication of efforts.
+If you're new to open source and feeling a bit nervous 😳, we understand! We recommend watching [this excellent guide](https://egghead.io/talks/git-how-to-make-your-first-open-source-contribution)
+to give you a grounding in some of the basic concepts. We want you to feel safe to make mistakes, and ask questions.
 
-Please do *not* add @author tags - this project embraces collective code
-ownership. If you want to know who wrote some code, look in git. When you are
-done, send a [pull request](http://help.github.com/send-pull-requests/).
-If we get a pull request where an entire file is changed because of
-insignificant whitespace changes we cannot see what you have changed, and your
-contribution might get rejected.
+If anything in this guide or anywhere else in the codebase doesn't make sense to you, please let us know! It's through your feedback that we can make this codebase more welcoming, so we'll be glad to hear thoughts.
+
+You can chat with us in the [#committers-go](https://cucumberbdd.slack.com/archives/CA5NJPDJ4) channel in our [community Slack], or feel free to [raise an issue] if you're experiencing any friction trying make your contribution.
+
+## Setup
+
+To get your development environment set up, you'll need to [install Go].
+
+Once that's done, try running the tests:
+
+    go test
+
+If everything passes, you're ready to hack!
+
+[install go](https://golang.org/doc/install)
+[community Slack]: https://cucumber.io/community#slack
+[raise an issue]: https://github.com/cucumber/godog/issues/new/choose

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,9 +13,13 @@ You can chat with us in the [#committers-go](https://cucumberbdd.slack.com/archi
 
 To get your development environment set up, you'll need to [install Go].
 
+Now install golint:
+
+    go install golang.org/x/lint/golint@latest
+
 Once that's done, try running the tests:
 
-    go test
+    make
 
 If everything passes, you're ready to hack!
 

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,16 @@
 
 VERS := $(shell grep 'const Version' -m 1 godog.go | awk -F\" '{print $$2}')
 
-test:
+EXPECTED_GO_VERSION = 1.17
+check-go-version:
+	@[[ "$(shell go version)" =~ $(EXPECTED_GO_VERSION) ]] || (echo Wrong go version! Please install $(EXPECTED_GO_VERSION) && exit 1)
+
+test: check-go-version
 	@echo "running all tests"
 	@go install ./...
 	@go fmt ./...
-	@golint github.com/cucumber/godog
-	@golint github.com/cucumber/godog/cmd/godog
+	@go run golang.org/x/lint/golint@latest github.com/cucumber/godog
+	@go run golang.org/x/lint/golint@latest github.com/cucumber/godog/cmd/godog
 	go vet ./...
 	go test -race
 	godog -f progress -c 4

--- a/README.md
+++ b/README.md
@@ -602,5 +602,5 @@ A simple example can be [found here](/_examples/custom-formatter).
 [behat]: http://docs.behat.org/ "Behavior driven development framework for PHP"
 [cucumber]: https://cucumber.io/ "Behavior driven development framework"
 [license]: https://en.wikipedia.org/wiki/MIT_License "The MIT license"
-[contributing guide]: [https://github.com/cucumber/godog/blob/main/CONTRIBUTING.md]
+[contributing guide]: https://github.com/cucumber/godog/blob/main/CONTRIBUTING.md
 [community Slack]: https://cucumber.io/community#slack

--- a/README.md
+++ b/README.md
@@ -56,16 +56,16 @@ GO111MODULE=on go get github.com/cucumber/godog/cmd/godog@v0.12.0
 
 ## Contributions
 
-Godog is a community driven Open Source Project within the Cucumber organization, it is maintained by a handfull of developers, but we appreciate contributions from everyone.
+Godog is a community driven Open Source Project within the Cucumber organization. We [welcome contributions from everyone](https://cucumber.io/blog/open-source/tackling-structural-racism-(and-sexism)-in-open-so/), and we're ready to support you if you have the enthusiasm to contribute.
 
-If you are interested in developing Godog, we suggest you to visit one of our slack channels.
+See the [contributing guide] for more detail on how to get started.
 
-Feel free to open a pull request. Note, if you wish to contribute larger changes or an extension to the exported methods or types, please open an issue before and visit us in slack to discuss the changes.
+## Getting help
 
-Reach out to the community on our [Cucumber Slack Community](https://cucumberbdd.slack.com/).
-Join [here](https://cucumberbdd-slack-invite.herokuapp.com/).
+We have a [community Slack] where you can chat with other users, developers, and BDD practitioners.
 
-### Popular Cucumber Slack channels for Godog:
+Here are some useful channels to try:
+
 - [#help-godog](https://cucumberbdd.slack.com/archives/CTNL1JCVA) - General Godog Adoption Help
 - [#committers-go](https://cucumberbdd.slack.com/archives/CA5NJPDJ4) - Golang focused Cucumber Contributors
 - [#committers](https://cucumberbdd.slack.com/archives/C62D0FK0E) - General Cucumber Contributors
@@ -602,3 +602,5 @@ A simple example can be [found here](/_examples/custom-formatter).
 [behat]: http://docs.behat.org/ "Behavior driven development framework for PHP"
 [cucumber]: https://cucumber.io/ "Behavior driven development framework"
 [license]: https://en.wikipedia.org/wiki/MIT_License "The MIT license"
+[contributing guide]: [https://github.com/cucumber/godog/blob/main/CONTRIBUTING.md]
+[community Slack]: https://cucumber.io/community#slack


### PR DESCRIPTION
A baby step towards #406.

Having paired with a new contributor on godog this week, I noticed how we don't really document how to hack on godog.

I also noticed how unwelcoming the CONTRIBUTING.md file was.

I've changed the tone to be warmer and more welcoming, and I've also made an attempt to explain what people need to do if they want to start hacking on godog.

It would be amazing to have some input here from others who have more familiarity with this codebase. For example, I noticed there's a `Makefile` with a `make test` target, but to run that I need to install golint which is deprecated. Should we still advise people to install that too, and use the `make test` target?

*Update* I figured out how to install `golint` so I've changed the instructions to model that.
