### PR TITLE
Add WSL friendly check-go-version setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- `check-go-version` in Makefile to run on WSL. ([]() - [mxygem])
+
 ## [v0.12.2]
 
 ### Fixed
@@ -146,8 +152,8 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 ### Changed
 
-- Run godog features in CircleCI in strict mode ([jaysonesmith])
-- Removed TestMain call in `suite_test.go` for CI. ([jaysonesmith])
+- Run godog features in CircleCI in strict mode ([mxygem])
+- Removed TestMain call in `suite_test.go` for CI. ([mxygem])
 - Migrated to [gherkin-go - v11.0.0](https://github.com/cucumber/gherkin-go/releases/tag/v11.0.0). ([240](https://github.com/cucumber/godog/pull/240) - [lonnblad])
 
 ### Deprecated
@@ -158,7 +164,7 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 - Fixed the time attributes in the JUnit formatter. ([232](https://github.com/cucumber/godog/pull/232) - [lonnblad])
 - Re enable custom formatters. ([238](https://github.com/cucumber/godog/pull/238) - [ericmcbride])
-- Added back suite_test.go ([jaysonesmith])
+- Added back suite_test.go ([mxygem])
 - Normalise module paths for use on Windows ([242](https://github.com/cucumber/godog/pull/242) - [gjtaylor])
 - Fixed panic in indenting function `s` ([247](https://github.com/cucumber/godog/pull/247) - [titouanfreville])
 - Fixed wrong version in API example ([263](https://github.com/cucumber/godog/pull/263) - [denis-trofimov])
@@ -181,18 +187,18 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 ### Fixed
 
 - Find/Replaced references to DATA-DOG/godog -> cucumber/godog for docs. ([209](https://github.com/cucumber/godog/pull/209) - [smikulcik])
-- Fixed missing links in changelog to be correctly included! ([jaysonesmith])
+- Fixed missing links in changelog to be correctly included! ([mxygem])
 
 ## [0.8.0]
 
 ### Added
 
-- Added initial CircleCI config. ([jaysonesmith])
+- Added initial CircleCI config. ([mxygem])
 - Added concurrency support for JUnit formatting ([lonnblad])
 
 ### Changed
 
-- Changed code references to DATA-DOG/godog to cucumber/godog to help get things building correctly. ([jaysonesmith])
+- Changed code references to DATA-DOG/godog to cucumber/godog to help get things building correctly. ([mxygem])
 
 ### Deprecated
 
@@ -214,7 +220,7 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 <!-- Contributors -->
 
 [axw]: https://github.com/axw
-[jaysonesmith]: https://github.com/jaysonesmith
+[mxygem]: https://github.com/mxygem
 [lonnblad]: https://github.com/lonnblad
 [smikulcik]: https://github.com/smikulcik
 [ericmcbride]: https://github.com/ericmcbride

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,11 @@
 
 VERS := $(shell grep 'const Version' -m 1 godog.go | awk -F\" '{print $$2}')
 
+FOUND_GO_VERSION := $(shell go version)
 EXPECTED_GO_VERSION = 1.17
+.PHONY: check-go-version
 check-go-version:
-	@[[ "$(shell go version)" =~ $(EXPECTED_GO_VERSION) ]] || (echo Wrong go version! Please install $(EXPECTED_GO_VERSION) && exit 1)
+	@$(if $(findstring ${EXPECTED_GO_VERSION}, ${FOUND_GO_VERSION}),,(echo Wrong go version! Please install ${EXPECTED_GO_VERSION}; exit 1))
 
 test: check-go-version
 	@echo "running all tests"


### PR DESCRIPTION
# Description

I've written a new version check that jives with WSL. I haven't tested this against macOS or other envs, so if others could help with that, I'd appreciate it!

# Motivation & context

Currently folks utilizing WSL are unable to run `make test` as execution of the version check fails.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have read the [**CONTRIBUTING**](../CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
