### PR TITLE
Invoke After Scenario hooks after After Step hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- After Scenario hook is called before After Step ([444](https://github.com/cucumber/godog/pull/444) - [vearutop])
+
 ## [v0.12.2]
 
 ### Fixed

--- a/features/events.feature
+++ b/features/events.feature
@@ -72,9 +72,9 @@ Feature: suite events
 
         Scenario: two
           Then passing step
-          And failing step
           And adding step state to context
           And having correct context
+          And failing step
 
         Scenario Outline: three
           Then passing step

--- a/suite.go
+++ b/suite.go
@@ -89,24 +89,22 @@ func (s *suite) runStep(ctx context.Context, pickle *Scenario, step *Step, prevS
 			}
 		}
 
-		defer func() {
-			// run after step handlers
-			rctx, err = s.runAfterStepHooks(ctx, step, sr.Status, err)
-		}()
+		earlyReturn := prevStepErr != nil || err == ErrUndefined
 
-		if prevStepErr != nil {
-			return
+		if !earlyReturn {
+			sr = models.NewStepResult(pickle.Id, step.Id, match)
 		}
 
-		if err == ErrUndefined {
-			return
-		}
-
-		sr = models.NewStepResult(pickle.Id, step.Id, match)
+		// Run after step handlers.
+		rctx, err = s.runAfterStepHooks(ctx, step, sr.Status, err)
 
 		// Trigger after scenario on failing or last step to attach possible hook error to step.
-		if (err == nil && isLast) || err != nil {
+		if sr.Status != StepSkipped && ((err == nil && isLast) || err != nil) {
 			rctx, err = s.runAfterScenarioHooks(rctx, pickle, err)
+		}
+
+		if earlyReturn {
+			return
 		}
 
 		switch err {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

This PR refactors hooks handling to improve invocation order.

This is not exactly a perfect solution for the problem, but an improvement. 

After Scenario will be invoked after step hooks of the last step in scenario or after a first failing step in scenario (all consecutive steps would have skipped status).

After Scenario will be invoked **before** skipped steps even though these steps are wrapped with step hooks.

Maybe it makes sense to disable step hooks for such steps for better consistency, but that may turn out a disruptive change of behavior.

# Motivation & context

Fixes #434

## Type of change

<!--- Delete any options that are not relevant -->

- Bug fix (non-breaking change which fixes an issue)


## Note to other contributors

No note.

## Update required of cucumber.io/docs

No update.

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](../CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
