### PR TITLE
use 'go get' instead of 'go install' to install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 ## [Unreleased]
 
+### Changed
+
+- suggest to use `go install` instead of the deprecated `go get` to install the `godog` binary ([449](https://github.com/cucumber/godog/pull/449) - [dmitris](https://github.com/dmitris))
+
 ### Fixed
 
 - After Scenario hook is called before After Step ([444](https://github.com/cucumber/godog/pull/444) - [vearutop])

--- a/README.md
+++ b/README.md
@@ -45,10 +45,11 @@ When automated testing is this much fun, teams can easily protect themselves fro
 
 ## Install
 ```
-go get github.com/cucumber/godog/cmd/godog@v0.12.0
+go install github.com/cucumber/godog/cmd/godog@v0.12.0
 ```
 Adding `@v0.12.0` will install v0.12.0 specifically instead of master.
 
+With `go` version prior to 1.17, use `go get github.com/cucumber/godog/cmd/godog@v0.12.0`.
 Running `within the $GOPATH`, you would also need to set `GO111MODULE=on`, like this:
 ```
 GO111MODULE=on go get github.com/cucumber/godog/cmd/godog@v0.12.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
PR modifies the README.md to use the modern `go install` instead of the deprecated `go get` method to install the binary.

# Motivation & context
https://go.dev/doc/go-get-install-deprecation

## Type of change

<!--- Delete any options that are not relevant -->

minor documentation change

## Note to other contributors

_If your change may impact future contributors, explain it here, and remember to update README.md and CONTRIBUTING.md accordingly._

## Update required of cucumber.io/docs

_If the [Cucumber documentation](https://cucumber.io/docs/) will require an update,
submit an issue or ideally a pull request to [cucumber/docs](https://github.com/cucumber/docs/) and
reference it here._

_e.g. "Ref: cucumber/docs/pull/#99"_

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [**CONTRIBUTING**](../CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
