### PR TITLE
Bump version

### DIFF
--- a/godog.go
+++ b/godog.go
@@ -39,4 +39,4 @@ Godog was inspired by Behat and Cucumber the above description is taken from it'
 package godog
 
 // Version of package - based on Semantic Versioning 2.0.0 http://semver.org/
-const Version = "v0.12.0"
+const Version = "v0.12.2"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Bumping the version since `godog version` reports `v0.12.0` while it should actually be `v0.12.2`.