### PR TITLE
Allow suite-level configuration of steps and hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- Allow suite-level configuration of steps and hooks ([453](https://github.com/cucumber/godog/pull/453) - [vearutop])
+
+
 ## [v0.12.3]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 - Allow suite-level configuration of steps and hooks ([453](https://github.com/cucumber/godog/pull/453) - [vearutop])
 
+## Changed
+
+- Run scenarios in the same goroutine if concurrency is disabled (([453](https://github.com/cucumber/godog/pull/453) - [vearutop]))
+
 
 ## [v0.12.3]
 

--- a/run.go
+++ b/run.go
@@ -57,7 +57,16 @@ func (r *runner) concurrent(rate int) (failed bool) {
 		fmt.SetStorage(r.storage)
 	}
 
-	testSuiteContext := TestSuiteContext{}
+	testSuiteContext := TestSuiteContext{
+		suite: &suite{
+			fmt:            r.fmt,
+			randomSeed:     r.randomSeed,
+			strict:         r.strict,
+			storage:        r.storage,
+			defaultContext: r.defaultContext,
+			testingT:       r.testingT,
+		},
+	}
 	if r.testSuiteInitializer != nil {
 		r.testSuiteInitializer(&testSuiteContext)
 	}
@@ -102,17 +111,11 @@ func (r *runner) concurrent(rate int) (failed bool) {
 					return
 				}
 
-				suite := &suite{
-					fmt:            r.fmt,
-					randomSeed:     r.randomSeed,
-					strict:         r.strict,
-					storage:        r.storage,
-					defaultContext: r.defaultContext,
-					testingT:       r.testingT,
-				}
+				// Copy base suite.
+				suite := *testSuiteContext.suite
 
 				if r.scenarioInitializer != nil {
-					sc := ScenarioContext{suite: suite}
+					sc := ScenarioContext{suite: &suite}
 					r.scenarioInitializer(&sc)
 				}
 

--- a/test_context.go
+++ b/test_context.go
@@ -86,10 +86,6 @@ func (ctx *TestSuiteContext) AfterSuite(fn func()) {
 
 // ScenarioContext allows registering scenario hooks.
 func (ctx *TestSuiteContext) ScenarioContext() *ScenarioContext {
-	if ctx.suite == nil {
-		ctx.suite = &suite{}
-	}
-
 	return &ScenarioContext{
 		suite: ctx.suite,
 	}

--- a/test_context.go
+++ b/test_context.go
@@ -3,13 +3,13 @@ package godog
 import (
 	"context"
 	"fmt"
-	"github.com/cucumber/messages-go/v16"
 	"reflect"
 	"regexp"
 
 	"github.com/cucumber/godog/formatters"
 	"github.com/cucumber/godog/internal/builder"
 	"github.com/cucumber/godog/internal/models"
+	"github.com/cucumber/messages-go/v16"
 )
 
 // GherkinDocument represents gherkin document.

--- a/test_context.go
+++ b/test_context.go
@@ -115,11 +115,11 @@ type StepContext struct {
 	suite *suite
 }
 
-// Before registers a a function or method
+// Before registers a function or method
 // to be run before every scenario.
 //
 // It is a good practice to restore the default state
-// before every scenario so it would be isolated from
+// before every scenario, so it would be isolated from
 // any kind of state.
 func (ctx ScenarioContext) Before(h BeforeScenarioHook) {
 	ctx.suite.beforeScenarioHandlers = append(ctx.suite.beforeScenarioHandlers, h)
@@ -151,7 +151,7 @@ func (ctx StepContext) Before(h BeforeStepHook) {
 // BeforeStepHook defines a hook before step.
 type BeforeStepHook func(ctx context.Context, st *Step) (context.Context, error)
 
-// After registers an function or method
+// After registers a function or method
 // to be run after every step.
 //
 // It may be convenient to return a different kind of error
@@ -183,7 +183,7 @@ func (ctx *ScenarioContext) BeforeScenario(fn func(sc *Scenario)) {
 	})
 }
 
-// AfterScenario registers an function or method
+// AfterScenario registers a function or method
 // to be run after every scenario.
 //
 // Deprecated: use After.
@@ -207,7 +207,7 @@ func (ctx *ScenarioContext) BeforeStep(fn func(st *Step)) {
 	})
 }
 
-// AfterStep registers an function or method
+// AfterStep registers a function or method
 // to be run after every step.
 //
 // It may be convenient to return a different kind of error

--- a/test_context.go
+++ b/test_context.go
@@ -3,10 +3,9 @@ package godog
 import (
 	"context"
 	"fmt"
+	"github.com/cucumber/messages-go/v16"
 	"reflect"
 	"regexp"
-
-	"github.com/cucumber/messages-go/v16"
 
 	"github.com/cucumber/godog/formatters"
 	"github.com/cucumber/godog/internal/builder"
@@ -66,6 +65,8 @@ type Table = messages.PickleTable
 type TestSuiteContext struct {
 	beforeSuiteHandlers []func()
 	afterSuiteHandlers  []func()
+
+	suite *suite
 }
 
 // BeforeSuite registers a function or method
@@ -81,6 +82,17 @@ func (ctx *TestSuiteContext) BeforeSuite(fn func()) {
 // to be run once after suite runner
 func (ctx *TestSuiteContext) AfterSuite(fn func()) {
 	ctx.afterSuiteHandlers = append(ctx.afterSuiteHandlers, fn)
+}
+
+// ScenarioContext allows registering scenario hooks.
+func (ctx *TestSuiteContext) ScenarioContext() *ScenarioContext {
+	if ctx.suite == nil {
+		ctx.suite = &suite{}
+	}
+
+	return &ScenarioContext{
+		suite: ctx.suite,
+	}
 }
 
 // ScenarioContext allows various contexts


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

During [discussion](https://github.com/cucumber/godog/discussions/452) it turned out step/hooks instrumentation happens for every scenario. 

# Motivation & context

Setting up steps/hooks for each scenario may be unnecessary overhead in most cases, as step/hooks handlers are usually identical for every scenario. Improvement idea is to create "global" setup in suite initializer and use it as a base for each scenario.

So that you could use
```go
TestSuiteInitializer: func(suiteContext *godog.TestSuiteContext) {
	local.RegisterSteps(suiteContext.ScenarioContext())
},
```
instead of or additionally to
```go
ScenarioInitializer: func(s *godog.ScenarioContext) {
	local.RegisterSteps(s)
},
```

Also, to simplify debugging, this PR runs scenario in the same goroutine when concurrency is disabled. This allows preserving original stack.

## Type of change

- New feature (non-breaking change which adds new behaviour)

## Note to other contributors

No note.

## Update required of cucumber.io/docs

No update.

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](../CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
