### PR TITLE
Fix version subcommand. Do not print usage if run subcommand fails.

### DIFF
--- a/cmd/godog/internal/cmd_run.go
+++ b/cmd/godog/internal/cmd_run.go
@@ -42,7 +42,6 @@ buildable go source.`,
 }
 
 func runCmdRunFunc(cmd *cobra.Command, args []string) error {
-
 	osArgs := os.Args[1:]
 
 	if len(osArgs) > 0 && osArgs[0] == "run" {

--- a/cmd/godog/internal/cmd_run.go
+++ b/cmd/godog/internal/cmd_run.go
@@ -32,7 +32,8 @@ buildable go source.`,
     feature (*.feature)
     scenario at specific line (*.feature:10)
   If no feature arguments are supplied, godog will use "features/" by default.`,
-		RunE: runCmdRunFunc,
+		RunE:         runCmdRunFunc,
+		SilenceUsage: true,
 	}
 
 	flags.BindRunCmdFlags("", runCmd.Flags(), &opts)
@@ -41,6 +42,7 @@ buildable go source.`,
 }
 
 func runCmdRunFunc(cmd *cobra.Command, args []string) error {
+
 	osArgs := os.Args[1:]
 
 	if len(osArgs) > 0 && osArgs[0] == "run" {

--- a/cmd/godog/internal/cmd_version.go
+++ b/cmd/godog/internal/cmd_version.go
@@ -14,6 +14,7 @@ func CreateVersionCmd() cobra.Command {
 	versionCmd := cobra.Command{
 		Use:     "version",
 		Short:   "Show current version",
+		Run:     versionCmdRunFunc,
 		Version: godog.Version,
 	}
 


### PR DESCRIPTION
### 🤔 What's changed?

`godog version` now prints the version number again and `godog run` will no longer print usage if a test fails.

### ⚡️ What's your motivation? 

* `godog version` wasn't printing the version number
* `godog run` was printing usage when a test failed, which cluttered up the output, and didn't seem intentional

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

Would you like the CHANGELOG updated for this?

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
