### PR TITLE
Setup Renovate with default Configs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "github>cucumber/renovate-config"
   ]
 }


### PR DESCRIPTION
### 🤔 What's changed?

This will setup Renovate with the [default Configs from the Cucumber org](https://github.com/cucumber/renovate-config). They're completely opt in but I find them to be quite sensible. With this configuration patch and minor releases that pass CI will automatically get merged without raising a PR. Major and failing builds will be raised as a PR. This should optimize the amount of manual work and notifications that needs to be done..

Note that currently Renovate has an open issue around updating transitive dependencies (https://github.com/renovatebot/renovate/issues/12999). This will cause some extra noise. Feel free to disable renovate by adding `"enabled": false` to the config file if it is too much.

### ⚡️ What's your motivation? 

The last few releases of Gherkin have been rather rocky for Go. Instead of relying on manual detection I'd like to automate this.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)
