### PR TITLE
Use `fs.FS` abstraction for filesystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 ## Unreleased
 ### Added
+- Support for reading feature files from an `fs.FS` ([550](https://github.com/cucumber/godog/pull/550)) - [tigh-latte](https://github.com/tigh-latte)
 - Added keyword functions. ([509](https://github.com/cucumber/godog/pull/509) - [otrava7](https://github.com/otrava7))
 - prefer go test to use of godog cli in README ([548](https://github.com/cucumber/godog/pull/548) - [danielhelfand](https://github.com/danielhelfand)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 ## Unreleased
 ### Added
-- Support for reading feature files from an `fs.FS` ([550](https://github.com/cucumber/godog/pull/550)) - [tigh-latte](https://github.com/tigh-latte)
+- Support for reading feature files from an `fs.FS` ([550](https://github.com/cucumber/godog/pull/550) - [tigh-latte](https://github.com/tigh-latte))
 - Added keyword functions. ([509](https://github.com/cucumber/godog/pull/509) - [otrava7](https://github.com/otrava7))
 - prefer go test to use of godog cli in README ([548](https://github.com/cucumber/godog/pull/548) - [danielhelfand](https://github.com/danielhelfand)
 

--- a/README.md
+++ b/README.md
@@ -521,6 +521,30 @@ func (a *asserter) Errorf(format string, args ...interface{}) {
 }
 ```
 
+### Embeds
+
+If you're looking to compile your test binary in advance of running, you can compile the feature files into the binary via `go:embed`:
+
+```go
+
+//go:embed features/*
+var features embed.FS
+
+var opts = godog.Options{
+	Paths: []string{"features"},
+	FS:    features,
+}
+```
+
+Now, the test binary can be compiled with all feature files embedded, and can be ran independently from the feature files:
+
+```sh
+> go test -c ./test/integration/integration_test.go
+> mv integration.test /some/random/dir
+> cd /some/random/dir
+> ./integration.test
+```
+
 ## CLI Mode
 
 **NOTE:** The [`godog` CLI has been deprecated](https://github.com/cucumber/godog/discussions/478). It is recommended to use `go test` instead.  

--- a/README.md
+++ b/README.md
@@ -545,6 +545,8 @@ Now, the test binary can be compiled with all feature files embedded, and can be
 > ./integration.test
 ```
 
+**NOTE:** `godog.Options.FS` is as `fs.FS`, so custom filesystem loaders can be used.
+
 ## CLI Mode
 
 **NOTE:** The [`godog` CLI has been deprecated](https://github.com/cucumber/godog/discussions/478). It is recommended to use `go test` instead.  

--- a/go.sum
+++ b/go.sum
@@ -46,7 +46,6 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=

--- a/internal/flags/options.go
+++ b/internal/flags/options.go
@@ -71,8 +71,8 @@ type Options struct {
 	// in a map entry
 	FeatureContents []Feature
 
-	// FS allows passing in an `fs.FS` to read features from, such as an `embed.FS`, or a
-	// directory other than `./`
+	// FS allows passing in an `fs.FS` to read features from, such as an `embed.FS`
+	// or os.DirFS(string). Defaults to os.DirFS("./").
 	FS fs.FS
 
 	// ShowHelp enables suite to show CLI flags usage help and exit.

--- a/internal/flags/options.go
+++ b/internal/flags/options.go
@@ -72,7 +72,7 @@ type Options struct {
 	FeatureContents []Feature
 
 	// FS allows passing in an `fs.FS` to read features from, such as an `embed.FS`
-	// or os.DirFS(string). Defaults to os.DirFS("./").
+	// or os.DirFS(string).
 	FS fs.FS
 
 	// ShowHelp enables suite to show CLI flags usage help and exit.

--- a/internal/flags/options.go
+++ b/internal/flags/options.go
@@ -3,6 +3,7 @@ package flags
 import (
 	"context"
 	"io"
+	"io/fs"
 	"testing"
 )
 
@@ -69,6 +70,10 @@ type Options struct {
 	// where the contents of each feature is stored as a byte slice
 	// in a map entry
 	FeatureContents []Feature
+
+	// FeatureEmbed allows passing in an `fs.FS` to read feature, such as an `embed.FS`, or a
+	// directory other than `./`
+	FeatureFS fs.FS
 
 	// ShowHelp enables suite to show CLI flags usage help and exit.
 	ShowHelp bool

--- a/internal/flags/options.go
+++ b/internal/flags/options.go
@@ -71,7 +71,7 @@ type Options struct {
 	// in a map entry
 	FeatureContents []Feature
 
-	// FeatureEmbed allows passing in an `fs.FS` to read feature, such as an `embed.FS`, or a
+	// FS allows passing in an `fs.FS` to read features from, such as an `embed.FS`, or a
 	// directory other than `./`
 	FS fs.FS
 

--- a/internal/flags/options.go
+++ b/internal/flags/options.go
@@ -73,7 +73,7 @@ type Options struct {
 
 	// FeatureEmbed allows passing in an `fs.FS` to read feature, such as an `embed.FS`, or a
 	// directory other than `./`
-	FeatureFS fs.FS
+	FS fs.FS
 
 	// ShowHelp enables suite to show CLI flags usage help and exit.
 	ShowHelp bool

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -110,7 +110,7 @@ func parsePath(fsys fs.FS, path string, newIDFunc func() string) ([]*models.Feat
 		return file.Stat()
 	}()
 	if err != nil {
-		return features, err
+		return features, fmt.Errorf("oh no: %w", err)
 	}
 
 	if fi.IsDir() {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -110,7 +110,7 @@ func parsePath(fsys fs.FS, path string, newIDFunc func() string) ([]*models.Feat
 		return file.Stat()
 	}()
 	if err != nil {
-		return features, fmt.Errorf("oh no: %w", err)
+		return features, err
 	}
 
 	if fi.IsDir() {

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1,7 +1,7 @@
 package parser_test
 
 import (
-	"os"
+	"io/fs"
 	"path/filepath"
 	"testing"
 	"testing/fstest"
@@ -71,14 +71,15 @@ Feature: eat godogs
     When I eat 5
     Then there should be 7 remaining`
 
-	baseDir := filepath.Join(os.TempDir(), t.Name(), "godogs")
-	fs := fstest.MapFS{
-		filepath.Join(baseDir, "a", featureFileName): {
+	baseDir := "base"
+	fsys := fstest.MapFS{
+		filepath.Join(baseDir, featureFileName): {
 			Data: []byte(eatGodogContents),
+			Mode: fs.FileMode(0644),
 		},
 	}
 
-	featureFromFile, err := parser.ParseFeatures(fs, "", []string{baseDir})
+	featureFromFile, err := parser.ParseFeatures(fsys, "", []string{baseDir})
 	require.NoError(t, err)
 	require.Len(t, featureFromFile, 1)
 
@@ -105,18 +106,20 @@ func Test_ParseFeatures_FromMultiplePaths(t *testing.T) {
     When I eat 5
 		Then there should be 7 remaining`
 
-	baseDir := filepath.Join(os.TempDir(), t.Name(), "godogs")
+	baseDir := "base"
 
-	fs := fstest.MapFS{
+	fsys := fstest.MapFS{
 		filepath.Join(baseDir, "a", featureFileName): {
 			Data: []byte(featureFileContents),
+			Mode: fs.FileMode(0644),
 		},
 		filepath.Join(baseDir, "b", featureFileName): {
 			Data: []byte(featureFileContents),
+			Mode: fs.FileMode(0644),
 		},
 	}
 
-	features, err := parser.ParseFeatures(fs, "", []string{baseDir + "/a", baseDir + "/b"})
+	features, err := parser.ParseFeatures(fsys, "", []string{baseDir + "/a", baseDir + "/b"})
 	assert.Nil(t, err)
 	assert.Len(t, features, 2)
 

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1,6 +1,7 @@
 package parser_test
 
 import (
+	"errors"
 	"io/fs"
 	"path/filepath"
 	"testing"
@@ -95,8 +96,9 @@ Feature: eat godogs
 }
 
 func Test_ParseFeatures_FromMultiplePaths(t *testing.T) {
-	const featureFileName = "godogs.feature"
-	const featureFileContents = `Feature: eat godogs
+	const (
+		defaultFeatureFile     = "godogs.feature"
+		defaultFeatureContents = `Feature: eat godogs
   In order to be happy
   As a hungry gopher
   I need to be able to eat godogs
@@ -105,32 +107,74 @@ func Test_ParseFeatures_FromMultiplePaths(t *testing.T) {
     Given there are 12 godogs
     When I eat 5
 		Then there should be 7 remaining`
+	)
 
-	baseDir := "base"
+	tests := map[string]struct {
+		fsys  fs.FS
+		paths []string
 
-	fsys := fstest.MapFS{
-		filepath.Join(baseDir, "a", featureFileName): {
-			Data: []byte(featureFileContents),
-			Mode: fs.FileMode(0644),
+		expFeatures int
+		expError    error
+	}{
+		"feature directories can be parsed": {
+			paths: []string{"base/a", "base/b"},
+			fsys: fstest.MapFS{
+				filepath.Join("base/a", defaultFeatureFile): {
+					Data: []byte(defaultFeatureContents),
+				},
+				filepath.Join("base/b", defaultFeatureFile): {
+					Data: []byte(defaultFeatureContents),
+				},
+			},
+			expFeatures: 2,
 		},
-		filepath.Join(baseDir, "b", featureFileName): {
-			Data: []byte(featureFileContents),
-			Mode: fs.FileMode(0644),
+		"path not found errors": {
+			fsys:     fstest.MapFS{},
+			paths:    []string{"base/a", "base/b"},
+			expError: errors.New(`feature path "base/a" is not available`),
+		},
+		"feature files can be parsed": {
+			paths: []string{
+				filepath.Join("base/a/", defaultFeatureFile),
+				filepath.Join("base/b/", defaultFeatureFile),
+			},
+			fsys: fstest.MapFS{
+				filepath.Join("base/a", defaultFeatureFile): {
+					Data: []byte(defaultFeatureContents),
+				},
+				filepath.Join("base/b", defaultFeatureFile): {
+					Data: []byte(defaultFeatureContents),
+				},
+			},
+			expFeatures: 2,
 		},
 	}
 
-	features, err := parser.ParseFeatures(fsys, "", []string{baseDir + "/a", baseDir + "/b"})
-	assert.Nil(t, err)
-	assert.Len(t, features, 2)
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
-	pickleIDs := map[string]bool{}
-	for _, f := range features {
-		for _, p := range f.Pickles {
-			if pickleIDs[p.Id] {
-				assert.Failf(t, "found duplicate pickle ID", "Pickle ID %s was already used", p.Id)
+			features, err := parser.ParseFeatures(test.fsys, "", test.paths)
+			if test.expError != nil {
+				require.Error(t, err)
+				require.EqualError(t, err, test.expError.Error())
+				return
 			}
 
-			pickleIDs[p.Id] = true
-		}
+			assert.Nil(t, err)
+			assert.Len(t, features, test.expFeatures)
+
+			pickleIDs := map[string]bool{}
+			for _, f := range features {
+				for _, p := range f.Pickles {
+					if pickleIDs[p.Id] {
+						assert.Failf(t, "found duplicate pickle ID", "Pickle ID %s was already used", p.Id)
+					}
+
+					pickleIDs[p.Id] = true
+				}
+			}
+		})
 	}
 }

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -80,7 +80,7 @@ Feature: eat godogs
 	err := ioutil.WriteFile(filepath.Join(baseDir, featureFileName), []byte(eatGodogContents), 0644)
 	require.Nil(t, err)
 
-	featureFromFile, err := parser.ParseFeatures("", []string{baseDir})
+	featureFromFile, err := parser.ParseFeatures(os.DirFS("./"), "", []string{baseDir})
 	require.NoError(t, err)
 	require.Len(t, featureFromFile, 1)
 
@@ -120,7 +120,7 @@ func Test_ParseFeatures_FromMultiplePaths(t *testing.T) {
 	err = ioutil.WriteFile(filepath.Join(baseDir+"/b", featureFileName), []byte(featureFileContents), 0644)
 	require.Nil(t, err)
 
-	features, err := parser.ParseFeatures("", []string{baseDir + "/a", baseDir + "/b"})
+	features, err := parser.ParseFeatures(os.DirFS("./"), "", []string{baseDir + "/a", baseDir + "/b"})
 	assert.Nil(t, err)
 	assert.Len(t, features, 2)
 

--- a/internal/storage/fs.go
+++ b/internal/storage/fs.go
@@ -1,0 +1,21 @@
+package storage
+
+import (
+	"io/fs"
+	"os"
+)
+
+// FS is a wrapper that falls back to `os`.
+type FS struct {
+	FS fs.FS
+}
+
+// Open a file in the provided `fs.FS`. If none provided,
+// open via `os.Open`
+func (f FS) Open(name string) (fs.File, error) {
+	if f.FS == nil {
+		return os.Open(name)
+	}
+
+	return f.FS.Open(name)
+}

--- a/internal/storage/fs_test.go
+++ b/internal/storage/fs_test.go
@@ -1,0 +1,109 @@
+package storage_test
+
+import (
+	"errors"
+	"io/fs"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	"github.com/cucumber/godog/internal/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStorage_Open_FS(t *testing.T) {
+	tests := map[string]struct {
+		fs fs.FS
+
+		expData  []byte
+		expError error
+	}{
+		"normal open": {
+			fs: fstest.MapFS{
+				"testfile": {
+					Data: []byte("hello worlds"),
+				},
+			},
+			expData: []byte("hello worlds"),
+		},
+		"file not found": {
+			fs:       fstest.MapFS{},
+			expError: errors.New("open testfile: file does not exist"),
+		},
+		"nil fs falls back on os": {
+			expError: errors.New("open testfile: no such file or directory"),
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			f, err := (storage.FS{FS: test.fs}).Open("testfile")
+			if test.expError != nil {
+				assert.Error(t, err)
+				assert.EqualError(t, err, test.expError.Error())
+				return
+			}
+
+			assert.NoError(t, err)
+
+			bb := make([]byte, len(test.expData))
+			_, _ = f.Read(bb)
+			assert.Equal(t, test.expData, bb)
+		})
+	}
+}
+
+func TestStorage_Open_OS(t *testing.T) {
+	tests := map[string]struct {
+		files    map[string][]byte
+		expData  []byte
+		expError error
+	}{
+		"normal open": {
+			files: map[string][]byte{
+				"testfile": []byte("hello worlds"),
+			},
+			expData: []byte("hello worlds"),
+		},
+		"nil fs falls back on os": {
+			expError: errors.New("open /tmp/TestStorage_Open_OS/nil_fs_falls_back_on_os/godogs/testfile: no such file or directory"),
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			baseDir := filepath.Join(os.TempDir(), t.Name(), "godogs")
+			err := os.MkdirAll(baseDir+"/a", 0755)
+			defer os.RemoveAll(baseDir)
+
+			require.Nil(t, err)
+
+			for name, data := range test.files {
+				err := ioutil.WriteFile(filepath.Join(baseDir, name), data, 0644)
+				require.NoError(t, err)
+			}
+
+			f, err := (storage.FS{}).Open(filepath.Join(baseDir, "testfile"))
+			if test.expError != nil {
+				assert.Error(t, err)
+				assert.EqualError(t, err, test.expError.Error())
+				return
+			}
+
+			assert.NoError(t, err)
+
+			bb := make([]byte, len(test.expData))
+			_, _ = f.Read(bb)
+			assert.Equal(t, test.expData, bb)
+		})
+	}
+}

--- a/run.go
+++ b/run.go
@@ -370,7 +370,7 @@ func getDefaultOptions() (*Options, error) {
 	}
 
 	opt.Paths = flagSet.Args()
-	opt.FS = storage.FS{FS: os.DirFS("./")}
+	opt.FS = storage.FS{}
 
 	return opt, nil
 }

--- a/run.go
+++ b/run.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"go/build"
 	"io"
+	"io/fs"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -350,7 +351,15 @@ func (ts TestSuite) RetrieveFeatures() ([]*models.Feature, error) {
 	}
 
 	if len(opt.Paths) == 0 {
-		inf, err := os.Stat("features")
+		inf, err := func() (fs.FileInfo, error) {
+			file, err := opt.FS.Open("features")
+			if err != nil {
+				return nil, err
+			}
+			defer file.Close()
+
+			return file.Stat()
+		}()
 		if err == nil && inf.IsDir() {
 			opt.Paths = []string{"features"}
 		}

--- a/run.go
+++ b/run.go
@@ -226,9 +226,7 @@ func runWithOptions(suiteName string, runner runner, opt Options) int {
 	}
 
 	runner.fmt = multiFmt.FormatterFunc(suiteName, output)
-	if opt.FS == nil {
-		opt.FS = os.DirFS("./")
-	}
+	opt.FS = storage.FS{FS: opt.FS}
 
 	if len(opt.FeatureContents) > 0 {
 		features, err := parser.ParseFromBytes(opt.Tags, opt.FeatureContents)
@@ -372,7 +370,7 @@ func getDefaultOptions() (*Options, error) {
 	}
 
 	opt.Paths = flagSet.Args()
-	opt.FS = os.DirFS("./")
+	opt.FS = storage.FS{FS: os.DirFS("./")}
 
 	return opt, nil
 }

--- a/run.go
+++ b/run.go
@@ -358,7 +358,7 @@ func (ts TestSuite) RetrieveFeatures() ([]*models.Feature, error) {
 		}
 	}
 
-	return parser.ParseFeatures(opt.Tags, opt.Paths)
+	return parser.ParseFeatures(os.DirFS("./"), opt.Tags, opt.Paths)
 }
 
 func getDefaultOptions() (*Options, error) {

--- a/run.go
+++ b/run.go
@@ -15,7 +15,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/cucumber/messages/go/v21"
+	messages "github.com/cucumber/messages/go/v21"
 
 	"github.com/cucumber/godog/colors"
 	"github.com/cucumber/godog/formatters"
@@ -226,6 +226,9 @@ func runWithOptions(suiteName string, runner runner, opt Options) int {
 	}
 
 	runner.fmt = multiFmt.FormatterFunc(suiteName, output)
+	if opt.FeatureFS == nil {
+		opt.FeatureFS = os.DirFS("./")
+	}
 
 	if len(opt.FeatureContents) > 0 {
 		features, err := parser.ParseFromBytes(opt.Tags, opt.FeatureContents)
@@ -237,7 +240,7 @@ func runWithOptions(suiteName string, runner runner, opt Options) int {
 	}
 
 	if len(opt.Paths) > 0 {
-		features, err := parser.ParseFeatures(opt.Tags, opt.Paths)
+		features, err := parser.ParseFeatures(opt.FeatureFS, opt.Tags, opt.Paths)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			return exitOptionError

--- a/run.go
+++ b/run.go
@@ -358,7 +358,7 @@ func (ts TestSuite) RetrieveFeatures() ([]*models.Feature, error) {
 		}
 	}
 
-	return parser.ParseFeatures(os.DirFS("./"), opt.Tags, opt.Paths)
+	return parser.ParseFeatures(opt.FS, opt.Tags, opt.Paths)
 }
 
 func getDefaultOptions() (*Options, error) {
@@ -372,6 +372,7 @@ func getDefaultOptions() (*Options, error) {
 	}
 
 	opt.Paths = flagSet.Args()
+	opt.FS = os.DirFS("./")
 
 	return opt, nil
 }

--- a/run.go
+++ b/run.go
@@ -226,8 +226,8 @@ func runWithOptions(suiteName string, runner runner, opt Options) int {
 	}
 
 	runner.fmt = multiFmt.FormatterFunc(suiteName, output)
-	if opt.FeatureFS == nil {
-		opt.FeatureFS = os.DirFS("./")
+	if opt.FS == nil {
+		opt.FS = os.DirFS("./")
 	}
 
 	if len(opt.FeatureContents) > 0 {
@@ -240,7 +240,7 @@ func runWithOptions(suiteName string, runner runner, opt Options) int {
 	}
 
 	if len(opt.Paths) > 0 {
-		features, err := parser.ParseFeatures(opt.FeatureFS, opt.Tags, opt.Paths)
+		features, err := parser.ParseFeatures(opt.FS, opt.Tags, opt.Paths)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			return exitOptionError

--- a/suite_context_test.go
+++ b/suite_context_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -559,7 +558,7 @@ func (tc *godogFeaturesScenario) featurePath(path string) {
 }
 
 func (tc *godogFeaturesScenario) parseFeatures() error {
-	fts, err := parser.ParseFeatures(os.DirFS("./"), "", tc.paths)
+	fts, err := parser.ParseFeatures(storage.FS{}, "", tc.paths)
 	if err != nil {
 		return err
 	}

--- a/suite_context_test.go
+++ b/suite_context_test.go
@@ -7,13 +7,14 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
 
-	"github.com/cucumber/gherkin/go/v26"
-	"github.com/cucumber/messages/go/v21"
+	gherkin "github.com/cucumber/gherkin/go/v26"
+	messages "github.com/cucumber/messages/go/v21"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/cucumber/godog/colors"
@@ -558,7 +559,7 @@ func (tc *godogFeaturesScenario) featurePath(path string) {
 }
 
 func (tc *godogFeaturesScenario) parseFeatures() error {
-	fts, err := parser.ParseFeatures("", tc.paths)
+	fts, err := parser.ParseFeatures(os.DirFS("./"), "", tc.paths)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

<!-- Describe your changes in detail -->

Allow users to supply a `fs.FS` to files from. If not provided, we will fallback to the standard `os` file operations.

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

As `fs.FS` is an interface it gives users flexibility beyond just the operating system's filesystem, such as mocking (see, for example, the tests. We no longer write data to `/tmp`) or at the very least, an in-memory fs. But the key feature is that it allows us to compile the feature files into an executable test binary, allowing that binary to be shipped independent from the feature files.

```go
//go:embed features/*
var featuresData embed.FS

...

var opts = godog.Options{
	Paths: []string{"features"},
	FS:    featureData,
}
```

Then we can just:
```sh
> go test -c ./test/integration/integration_test.go
> mv integration.test /some/random/dir
> cd /some/random/dir
> ./integration.test
```

Currently I embed all  test data into my test suite, and sometimes deploy these tests into a restricted environment for some non-user facing service tests in a live environment. With the current set up of godog, I have to also be concerned with shipping the feature files and placing them the correct location on the filesystem. This change would let users just fire a test binary into a scratch container and run without being concerned the underlying filesystem.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)
- :zap: New feature (non-breaking change which adds new behaviour)


### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
