### PR TITLE
fix invalid memory address or nil pointer dereference in RetrieveFeatures

### DIFF
--- a/run.go
+++ b/run.go
@@ -361,6 +361,10 @@ func (ts TestSuite) RetrieveFeatures() ([]*models.Feature, error) {
 		}
 	}
 
+	if ts.Options.FS == nil {
+		ts.Options.FS = storage.FS{}
+	}
+
 	if len(opt.Paths) == 0 {
 		inf, err := func() (fs.FileInfo, error) {
 			file, err := opt.FS.Open("features")


### PR DESCRIPTION
fix invalid memory address or nil pointer dereference when calling TestSuite RetrieveFeatures

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
