### PR TITLE
Provide access to the testing.T log function in the context

### DIFF
--- a/suite.go
+++ b/suite.go
@@ -522,6 +522,7 @@ func (s *suite) runPickle(pickle *messages.Pickle) (err error) {
 	if s.testingT != nil {
 		// Running scenario as a subtest.
 		s.testingT.Run(pickle.Name, func(t *testing.T) {
+			ctx = setContextLogger(ctx, t)
 			ctx, err = s.runSteps(ctx, pickle, pickle.Steps)
 			if s.shouldFail(err) {
 				t.Errorf("%+v", err)
@@ -535,4 +536,23 @@ func (s *suite) runPickle(pickle *messages.Pickle) (err error) {
 	// so that error from handler can be added to step.
 
 	return err
+}
+
+type TestLogger interface {
+	Log(args ...interface{})
+	Logf(format string, args ...interface{})
+}
+
+type logCtxVal struct{}
+
+func setContextLogger(ctx context.Context, t TestLogger) context.Context {
+	return context.WithValue(ctx, logCtxVal{}, t)
+}
+
+func GetTestLogger(ctx context.Context) TestLogger {
+	t, ok := ctx.Value(logCtxVal{}).(TestLogger)
+	if !ok {
+		return nil
+	}
+	return t
 }


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

Simply adding an interface over testing.T's log and logf functions to the context, allowing logging of information contextually. Vaguely related to #535 and #100 as, if this pattern is OK, it could be expanded to provide the whole of testing.T.

Example usage:
```
func log(ctx context.Context, msg string, args ...interface{}) {
	if t := godog.GetTestLogger(ctx); t != nil {
		t.Logf(msg, args...)
	} else {
		fmt.Println(fmt.Printf(msg, args...))
	}
}
```

### ⚡️ What's your motivation? 

We have longer-running asynchronous tests which, when run, we want to provide contextual feedback to the user on during the execution. By using the sub-test's testing.T, these log messages appear in a sane place in the formatted output.

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?

Opening this early for feedback - if it is conceptually sane, I'll work this PR up to a better state and add docs - didn't want to bother documenting it in detail if it's not going to be acceptable tho!

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
