### PR TITLE
updated base formatter to set a scenario as passed unless there exist…

### DIFF
--- a/internal/formatters/fmt_base.go
+++ b/internal/formatters/fmt_base.go
@@ -106,7 +106,6 @@ func (f *Base) Summary() {
 
 			switch sr.Status {
 			case passed:
-				prStatus = passed
 				passedSt++
 			case failed:
 				prStatus = failed
@@ -114,10 +113,8 @@ func (f *Base) Summary() {
 			case skipped:
 				skippedSt++
 			case undefined:
-				prStatus = undefined
 				undefinedSt++
 			case pending:
-				prStatus = pending
 				pendingSt++
 			}
 		}

--- a/internal/formatters/fmt_base.go
+++ b/internal/formatters/fmt_base.go
@@ -113,8 +113,10 @@ func (f *Base) Summary() {
 			case skipped:
 				skippedSt++
 			case undefined:
+				prStatus = undefined
 				undefinedSt++
 			case pending:
+				prStatus = pending
 				pendingSt++
 			}
 		}


### PR DESCRIPTION
### 🤔 What's changed?
I have updated the step evaluation in the base formatter to not set a scenario as passed just because some step has passed. A scenario, after this change, will only be passed only if no steps exist that are `failed`, `pending` or `undefined` in that scenario.


### ⚡️ What's your motivation? 
Issue #581 was created because of this. I was able to reproduce it easily. All I had to do was update the [api test feature] like the following (only updated the `method not allowed` to `method allowed`
```
# file: version.feature
Feature: get version
  In order to know godog version
  As an API user
  I need to be able to request version

  Scenario: does not allow POST method
    When I send "POST" request to "/version"
    Then the response code should be 405
    And the response should match json:
      """
      {
        "error": "Method allowed"
      }
      """

  Scenario: should get version number
    When I send "GET" request to "/version"
    Then the response code should be 200
    And the response should match json:
      """
      {
        "version": "v0.0.0-dev"
      }
      """

```
The summary for the above change is as follows
![image](https://github.com/cucumber/godog/assets/45606754/78a791e5-45be-4bb3-9b97-b534f93047cd)

As it can be seen from the picture, the total scenarios (2) does not much the sum of passed (2) and failed (1) scenarios. This is due to the steps overriding the scenario status. That is, if a failed step is evaluated first, it will set the scenario as failed. but the next passing step will override that state and make it as passed. But when the summary is prepared the number of failed scenarios is evaluated as the number of failed steps (since a failed step will always lead to a failed scenario and other dependent steps are skipped, this logic works). This leads to the incorrect sum in the above result.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?
I am not sure if this issue is only on the base formatter implementation. If there are any other implementations of the formatter I should look into, please let me know :pray: 
<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
