### PR TITLE
Improve ErrSkip handling, add test for Summary and operations order

### DIFF
--- a/internal/formatters/fmt_base_test.go
+++ b/internal/formatters/fmt_base_test.go
@@ -1,0 +1,151 @@
+package formatters_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/cucumber/godog"
+	"github.com/cucumber/godog/internal/flags"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBase_Summary(t *testing.T) {
+	var features []flags.Feature
+
+	features = append(features,
+		flags.Feature{Name: "f1", Contents: []byte(`
+Feature: f1
+
+Scenario: f1s1
+When step passed f1s1:1
+Then step failed f1s1:2
+`)},
+		flags.Feature{Name: "f2", Contents: []byte(`
+Feature: f2
+
+Scenario: f2s1
+When step passed f2s1:1
+Then step passed f2s1:2
+
+Scenario: f2s2
+When step failed f2s2:1
+Then step passed f2s2:2
+
+Scenario: f2s3
+When step passed f2s3:1
+Then step skipped f2s3:2
+And step passed f2s3:3
+And step failed f2s3:4
+
+Scenario: f2s4
+When step passed f2s4:1
+Then step is undefined f2s4:2
+And step passed f2s4:3
+`)},
+	)
+
+	out := bytes.NewBuffer(nil)
+	suite := godog.TestSuite{
+		ScenarioInitializer: func(sc *godog.ScenarioContext) {
+			sc.After(func(ctx context.Context, sc *godog.Scenario, err error) (context.Context, error) {
+				if err != nil {
+					_, _ = out.WriteString(fmt.Sprintf("scenario %q ended with error %q\n", sc.Name, err.Error()))
+				} else {
+					_, _ = out.WriteString(fmt.Sprintf("scenario %q passed\n", sc.Name))
+				}
+
+				return ctx, nil
+			})
+			sc.StepContext().After(func(ctx context.Context, st *godog.Step, status godog.StepResultStatus, err error) (context.Context, error) {
+				_, _ = out.WriteString(fmt.Sprintf("step %q finished with status %s\n", st.Text, status.String()))
+				return ctx, nil
+			})
+			sc.Step("failed (.+)", func(s string) error {
+				_, _ = out.WriteString(fmt.Sprintf("\nstep invoked: %q, failed\n", s))
+				return errors.New("failed")
+			})
+			sc.Step("skipped (.+)", func(s string) error {
+				_, _ = out.WriteString(fmt.Sprintf("\nstep invoked: %q, skipped\n", s))
+				return godog.ErrSkip
+			})
+			sc.Step("passed (.+)", func(s string) {
+				_, _ = out.WriteString(fmt.Sprintf("\nstep invoked: %q, passed\n", s))
+			})
+		},
+		Options: &godog.Options{
+			Output:          out,
+			NoColors:        true,
+			Strict:          true,
+			Format:          "progress",
+			FeatureContents: features,
+		},
+	}
+
+	assert.Equal(t, 1, suite.Run())
+	assert.Equal(t, `
+step invoked: "f1s1:1", passed
+step "step passed f1s1:1" finished with status passed
+.
+step invoked: "f1s1:2", failed
+step "step failed f1s1:2" finished with status failed
+scenario "f1s1" ended with error "failed"
+F
+step invoked: "f2s1:1", passed
+step "step passed f2s1:1" finished with status passed
+.
+step invoked: "f2s1:2", passed
+step "step passed f2s1:2" finished with status passed
+scenario "f2s1" passed
+.
+step invoked: "f2s2:1", failed
+step "step failed f2s2:1" finished with status failed
+scenario "f2s2" ended with error "failed"
+F-step "step passed f2s2:2" finished with status skipped
+
+step invoked: "f2s3:1", passed
+step "step passed f2s3:1" finished with status passed
+.
+step invoked: "f2s3:2", skipped
+step "step skipped f2s3:2" finished with status skipped
+--step "step passed f2s3:3" finished with status skipped
+-step "step failed f2s3:4" finished with status skipped
+scenario "f2s3" passed
+
+step invoked: "f2s4:1", passed
+step "step passed f2s4:1" finished with status passed
+.Ustep "step is undefined f2s4:2" finished with status undefined
+scenario "f2s4" ended with error "step is undefined"
+-step "step passed f2s4:3" finished with status skipped
+ 13
+
+
+--- Failed steps:
+
+  Scenario: f1s1 # f1:4
+    Then step failed f1s1:2 # f1:6
+      Error: failed
+
+  Scenario: f2s2 # f2:8
+    When step failed f2s2:1 # f2:9
+      Error: failed
+
+
+5 scenarios (2 passed, 2 failed, 1 undefined)
+13 steps (5 passed, 2 failed, 1 undefined, 5 skipped)
+0s
+
+You can implement step definitions for undefined steps with these snippets:
+
+func stepIsUndefinedFS(arg1, arg2, arg3 int) error {
+	return godog.ErrPending
+}
+
+func InitializeScenario(ctx *godog.ScenarioContext) {
+	ctx.Step(`+"`"+`^step is undefined f(\d+)s(\d+):(\d+)$`+"`"+`, stepIsUndefinedFS)
+}
+
+`, out.String())
+}


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

This PR
* Updates some of the error checks with `errors.Is` for better reliability with wrapping
* Adds missing handling of step result statuses for `ErrSkip`
* Adds a test to validate formatter `Summary()` and step execution flow

### ⚡️ What's your motivation? 

#582 introduced a fix that was invisible for current test suite (tests passing before and after), while covering the fix with a regression test it turned out, `ErrSkip` is not properly reported in `Summary()`.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
