### PR TITLE
added support for Attachments (aka Embedddings)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ Gopkg.toml
 .vscode
 
 _artifacts
+
+vendor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 ## [v0.14.1]
 
 ### Added
+- Provide support for attachments / embeddings  - ([623](https://github.com/cucumber/godog/pull/623) - [johnlon](https://github.com/johnlon))
 - Provide testing.T-compatible interface on test context, allowing usage of assertion libraries such as testify's assert/require - ([571](https://github.com/cucumber/godog/pull/571) - [mrsheepuk](https://github.com/mrsheepuk))
 - Created releasing guidelines - ([608](https://github.com/cucumber/godog/pull/608) - [glibas](https://github.com/glibas))
 

--- a/README.md
+++ b/README.md
@@ -580,3 +580,4 @@ A simple example can be [found here](/_examples/custom-formatter).
 [contributing guide]: https://github.com/cucumber/godog/blob/main/CONTRIBUTING.md
 [releasing guide]: https://github.com/cucumber/godog/blob/main/RELEASING.md
 [community Slack]: https://cucumber.io/community#slack
+

--- a/README.md
+++ b/README.md
@@ -582,3 +582,4 @@ A simple example can be [found here](/_examples/custom-formatter).
 [community Slack]: https://cucumber.io/community#slack
 
 
+

--- a/README.md
+++ b/README.md
@@ -580,4 +580,3 @@ A simple example can be [found here](/_examples/custom-formatter).
 [contributing guide]: https://github.com/cucumber/godog/blob/main/CONTRIBUTING.md
 [releasing guide]: https://github.com/cucumber/godog/blob/main/RELEASING.md
 [community Slack]: https://cucumber.io/community#slack
-

--- a/README.md
+++ b/README.md
@@ -581,3 +581,4 @@ A simple example can be [found here](/_examples/custom-formatter).
 [releasing guide]: https://github.com/cucumber/godog/blob/main/RELEASING.md
 [community Slack]: https://cucumber.io/community#slack
 
+

--- a/internal/formatters/fmt_events.go
+++ b/internal/formatters/fmt_events.go
@@ -153,6 +153,32 @@ func (f *Events) step(pickle *messages.Pickle, pickleStep *messages.PickleStep) 
 	if pickleStepResult.Err != nil {
 		errMsg = pickleStepResult.Err.Error()
 	}
+	// JL
+
+	if pickleStepResult.Attachments != nil {
+		for _, attachment := range pickleStepResult.Attachments {
+
+			f.event(&struct {
+				Event           string `json:"event"`
+				Location        string `json:"location"`
+				Timestamp       int64  `json:"timestamp"`
+				ContentEncoding string `json:"contentEncoding"`
+				FileName        string `json:"fileName"`
+				MimeType        string `json:"mimeType"`
+				Body            string `json:"body"`
+			}{
+				"Attachment",
+				fmt.Sprintf("%s:%d", pickle.Uri, step.Location.Line),
+				utils.TimeNowFunc().UnixNano() / nanoSec,
+				messages.AttachmentContentEncoding_BASE64.String(),
+				attachment.Name,
+				attachment.MimeType,
+				string(attachment.Data),
+			})
+
+		}
+	}
+
 	f.event(&struct {
 		Event     string `json:"event"`
 		Location  string `json:"location"`

--- a/internal/formatters/fmt_events.go
+++ b/internal/formatters/fmt_events.go
@@ -153,7 +153,6 @@ func (f *Events) step(pickle *messages.Pickle, pickleStep *messages.PickleStep) 
 	if pickleStepResult.Err != nil {
 		errMsg = pickleStepResult.Err.Error()
 	}
-	// JL
 
 	if pickleStepResult.Attachments != nil {
 		for _, attachment := range pickleStepResult.Attachments {

--- a/internal/formatters/formatter-tests/cucumber/scenario_with_attachment
+++ b/internal/formatters/formatter-tests/cucumber/scenario_with_attachment
@@ -1,0 +1,46 @@
+[
+    {
+        "uri": "formatter-tests/features/scenario_with_attachment.feature",
+        "id": "scenario-with-attachment",
+        "keyword": "Feature",
+        "name": "scenario with attachment",
+        "description": "  describes\n  an attachment\n  feature",
+        "line": 1,
+        "elements": [
+            {
+                "id": "scenario-with-attachment;step-with-attachment",
+                "keyword": "Scenario",
+                "name": "step with attachment",
+                "description": "",
+                "line": 6,
+                "type": "scenario",
+                "steps": [
+                    {
+                        "keyword": "Given ",
+                        "name": "a step with attachment",
+                        "line": 7,
+                        "match": {
+                            "location": "fmt_output_test.go:119"
+                        },
+                        "result": {
+                            "status": "passed",
+                            "duration": 0
+                        },
+                        "embeddings": [
+                            {
+                                "name": "TheFilename1",
+                                "mime_type": "text/plain",
+                                "data": "VGhlRGF0YTE"
+                            },
+                            {
+                                "name": "TheFilename2",
+                                "mime_type": "text/plain",
+                                "data": "VGhlRGF0YTI"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+]

--- a/internal/formatters/formatter-tests/events/scenario_with_attachment
+++ b/internal/formatters/formatter-tests/events/scenario_with_attachment
@@ -1,0 +1,10 @@
+{"event":"TestRunStarted","version":"0.1.0","timestamp":-6795364578871,"suite":"events"}
+{"event":"TestSource","location":"formatter-tests/features/scenario_with_attachment.feature:1","source":"Feature: scenario with attachment\n  describes\n  an attachment\n  feature\n\n  Scenario: step with attachment\n    Given a step with attachment\n"}
+{"event":"TestCaseStarted","location":"formatter-tests/features/scenario_with_attachment.feature:6","timestamp":-6795364578871}
+{"event":"StepDefinitionFound","location":"formatter-tests/features/scenario_with_attachment.feature:7","definition_id":"fmt_output_test.go:XXX -\u003e github.com/cucumber/godog/internal/formatters_test.stepWithAttachment","arguments":[]}
+{"event":"TestStepStarted","location":"formatter-tests/features/scenario_with_attachment.feature:7","timestamp":-6795364578871}
+{"event":"Attachment","location":"formatter-tests/features/scenario_with_attachment.feature:7","timestamp":-6795364578871,"contentEncoding":"BASE64","fileName":"TheFilename1","mimeType":"text/plain","body":"TheData1"}
+{"event":"Attachment","location":"formatter-tests/features/scenario_with_attachment.feature:7","timestamp":-6795364578871,"contentEncoding":"BASE64","fileName":"TheFilename2","mimeType":"text/plain","body":"TheData2"}
+{"event":"TestStepFinished","location":"formatter-tests/features/scenario_with_attachment.feature:7","timestamp":-6795364578871,"status":"passed"}
+{"event":"TestCaseFinished","location":"formatter-tests/features/scenario_with_attachment.feature:6","timestamp":-6795364578871,"status":"passed"}
+{"event":"TestRunFinished","status":"passed","timestamp":-6795364578871,"snippets":"","memory":""}

--- a/internal/formatters/formatter-tests/features/scenario_with_attachment.feature
+++ b/internal/formatters/formatter-tests/features/scenario_with_attachment.feature
@@ -1,0 +1,7 @@
+Feature: scenario with attachment
+  describes
+  an attachment
+  feature
+
+  Scenario: step with attachment
+    Given a step with attachment

--- a/internal/models/results.go
+++ b/internal/models/results.go
@@ -18,6 +18,13 @@ type PickleResult struct {
 	StartedAt time.Time
 }
 
+// PickleAttachment ...
+type PickleAttachment struct {
+	Name     string
+	MimeType string
+	Data     []byte
+}
+
 // PickleStepResult ...
 type PickleStepResult struct {
 	Status     StepResultStatus
@@ -28,6 +35,8 @@ type PickleStepResult struct {
 	PickleStepID string
 
 	Def *StepDefinition
+
+	Attachments []*PickleAttachment
 }
 
 // NewStepResult ...
@@ -35,6 +44,7 @@ func NewStepResult(
 	status StepResultStatus,
 	pickleID, pickleStepID string,
 	match *StepDefinition,
+	attachments []*PickleAttachment,
 	err error,
 ) PickleStepResult {
 	return PickleStepResult{
@@ -44,6 +54,7 @@ func NewStepResult(
 		PickleID:     pickleID,
 		PickleStepID: pickleStepID,
 		Def:          match,
+		Attachments:  attachments,
 	}
 }
 

--- a/suite.go
+++ b/suite.go
@@ -592,3 +592,4 @@ func (s *suite) runPickle(pickle *messages.Pickle) (err error) {
 
 	return err
 }
+

--- a/suite.go
+++ b/suite.go
@@ -90,18 +90,18 @@ func Attachments(ctx context.Context) []Attachment {
 
 func pickleAttachments(ctx context.Context) []*models.PickleAttachment {
 
-	pickedAttachments := []*models.PickleAttachment{}
+	pickledAttachments := []*models.PickleAttachment{}
 	attachments := Attachments(ctx)
 
 	for _, a := range attachments {
-		pickedAttachments = append(pickedAttachments, &models.PickleAttachment{
+		pickledAttachments = append(pickledAttachments, &models.PickleAttachment{
 			Name:     a.FileName,
 			Data:     a.Body,
 			MimeType: a.MediaType,
 		})
 	}
 
-	return pickedAttachments
+	return pickledAttachments
 }
 
 func (s *suite) matchStep(step *messages.PickleStep) *models.StepDefinition {
@@ -160,8 +160,7 @@ func (s *suite) runStep(ctx context.Context, pickle *Scenario, step *Step, scena
 			status = StepPassed
 		}
 
-		// JL
-		pickedAttachments := pickleAttachments(ctx)
+		pickledAttachments := pickleAttachments(ctx)
 		ctx = Attach(ctx)
 
 		// Run after step handlers.
@@ -180,19 +179,19 @@ func (s *suite) runStep(ctx context.Context, pickle *Scenario, step *Step, scena
 
 		switch {
 		case err == nil:
-			sr := models.NewStepResult(models.Passed, pickle.Id, step.Id, match, pickedAttachments, nil)
+			sr := models.NewStepResult(models.Passed, pickle.Id, step.Id, match, pickledAttachments, nil)
 			s.storage.MustInsertPickleStepResult(sr)
 			s.fmt.Passed(pickle, step, match.GetInternalStepDefinition())
 		case errors.Is(err, ErrPending):
-			sr := models.NewStepResult(models.Pending, pickle.Id, step.Id, match, pickedAttachments, nil)
+			sr := models.NewStepResult(models.Pending, pickle.Id, step.Id, match, pickledAttachments, nil)
 			s.storage.MustInsertPickleStepResult(sr)
 			s.fmt.Pending(pickle, step, match.GetInternalStepDefinition())
 		case errors.Is(err, ErrSkip):
-			sr := models.NewStepResult(models.Skipped, pickle.Id, step.Id, match, pickedAttachments, nil)
+			sr := models.NewStepResult(models.Skipped, pickle.Id, step.Id, match, pickledAttachments, nil)
 			s.storage.MustInsertPickleStepResult(sr)
 			s.fmt.Skipped(pickle, step, match.GetInternalStepDefinition())
 		default:
-			sr := models.NewStepResult(models.Failed, pickle.Id, step.Id, match, pickedAttachments, err)
+			sr := models.NewStepResult(models.Failed, pickle.Id, step.Id, match, pickledAttachments, err)
 			s.storage.MustInsertPickleStepResult(sr)
 			s.fmt.Failed(pickle, step, match.GetInternalStepDefinition(), err)
 		}
@@ -211,11 +210,10 @@ func (s *suite) runStep(ctx context.Context, pickle *Scenario, step *Step, scena
 	s.fmt.Defined(pickle, step, match.GetInternalStepDefinition())
 
 	if err != nil {
-
-		pickedAttachments := pickleAttachments(ctx)
+		pickledAttachments := pickleAttachments(ctx)
 		ctx = Attach(ctx)
 
-		sr := models.NewStepResult(models.Failed, pickle.Id, step.Id, match, pickedAttachments, nil)
+		sr := models.NewStepResult(models.Failed, pickle.Id, step.Id, match, pickledAttachments, nil)
 		s.storage.MustInsertPickleStepResult(sr)
 		return ctx, err
 	}
@@ -237,10 +235,10 @@ func (s *suite) runStep(ctx context.Context, pickle *Scenario, step *Step, scena
 			}
 		}
 
-		pickedAttachments := pickleAttachments(ctx)
+		pickledAttachments := pickleAttachments(ctx)
 		ctx = Attach(ctx)
 
-		sr := models.NewStepResult(models.Undefined, pickle.Id, step.Id, match, pickedAttachments, nil)
+		sr := models.NewStepResult(models.Undefined, pickle.Id, step.Id, match, pickledAttachments, nil)
 		s.storage.MustInsertPickleStepResult(sr)
 
 		s.fmt.Undefined(pickle, step, match.GetInternalStepDefinition())
@@ -248,10 +246,10 @@ func (s *suite) runStep(ctx context.Context, pickle *Scenario, step *Step, scena
 	}
 
 	if scenarioErr != nil {
-		pickedAttachments := pickleAttachments(ctx)
+		pickledAttachments := pickleAttachments(ctx)
 		ctx = Attach(ctx)
 
-		sr := models.NewStepResult(models.Skipped, pickle.Id, step.Id, match, pickedAttachments, nil)
+		sr := models.NewStepResult(models.Skipped, pickle.Id, step.Id, match, pickledAttachments, nil)
 		s.storage.MustInsertPickleStepResult(sr)
 
 		s.fmt.Skipped(pickle, step, match.GetInternalStepDefinition())

--- a/suite.go
+++ b/suite.go
@@ -592,4 +592,3 @@ func (s *suite) runPickle(pickle *messages.Pickle) (err error) {
 
 	return err
 }
-

--- a/suite.go
+++ b/suite.go
@@ -210,6 +210,7 @@ func (s *suite) runStep(ctx context.Context, pickle *Scenario, step *Step, scena
 	s.fmt.Defined(pickle, step, match.GetInternalStepDefinition())
 
 	if err != nil {
+
 		pickledAttachments := pickleAttachments(ctx)
 		ctx = Attach(ctx)
 


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

The cucumber and events formatters support the inclusion of Attachments.

The proposed API is demonstrated in the tests as  ...


    func stepWithAttachment(ctx context.Context) (context.Context, error) {
	    ctxOut := godog.Attach(ctx,
		godog.Attachment{Body: []byte("TheData1"), FileName: "TheFilename1", MediaType: "text/plain"},
		godog.Attachment{Body: []byte("TheData2"), FileName: "TheFilename2", MediaType: "text/plain"},
	    )

	    return ctxOut, nil
    }


### ⚡️ What's your motivation? 

https://github.com/cucumber/godog/issues/617

Want support for Attachments from steps.
This PR proposes to use the context.Context object as a means to attach content from the step.



### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)


### ♻️ Anything particular you want feedback on?

This change involves minimal changes to patterns of use of godog API's.

I added tests for the cuke and events formats but the coverage isn't being recorded even on some lines I didn't modify.

fmt_output_test.go now has a normalise() fn that eliminates some extraneous diffs in the actual/expected files such as line endings and also line numbers so that the tests are easier to maintain and cross platform,

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
