### PR TITLE
Moved CHANGHELOG entry to correct location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 ## Unreleased
 
+- Provide support for attachments / embeddings  - ([623](https://github.com/cucumber/godog/pull/623) - [johnlon](https://github.com/johnlon))
+
 ## [v0.14.1]
 
 ### Added
-- Provide support for attachments / embeddings  - ([623](https://github.com/cucumber/godog/pull/623) - [johnlon](https://github.com/johnlon))
 - Provide testing.T-compatible interface on test context, allowing usage of assertion libraries such as testify's assert/require - ([571](https://github.com/cucumber/godog/pull/571) - [mrsheepuk](https://github.com/mrsheepuk))
 - Created releasing guidelines - ([608](https://github.com/cucumber/godog/pull/608) - [glibas](https://github.com/glibas))
 


### PR DESCRIPTION
Moved a changelog entry to the correct location 
<!---

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

--