### PR TITLE
Document installing the godog module

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ godogs
 - godogs_test.go
 ```
 
-Run `go test` in the **godogs** directory to run the steps you have defined. You should now see that the scenario runs 
-with a warning stating there are no tests to run. 
+Run `go get github.com/cucumber/godog`, `go mod tidy`, and `go test` in the **godogs** directory to run the steps you have defined. 
+You should now see that the scenario runs with a warning stating there are no tests to run. 
 ```
 testing: warning: no tests to run
 PASS


### PR DESCRIPTION
### 🤔 What's changed?

The `go get github.com/cucumber/godog` step fixes this error:

```
godogs_test.go:3:8: no required module provides package github.com/cucumber/godog; to add it:
        go get github.com/cucumber/godog
FAIL    godogs [setup failed]
```

The step `go mod tidy`  eliminates this warning emitted by gopls:

```
github.com/cucumber/godog should be direct
```

### ⚡️ What's your motivation? 

More people should use Cucumber. If the tutorial doesn't work, people give up switching to it.

### 🏷️ What kind of change is this?

:book: Documentation (improvements without changing code)

### ♻️ Anything particular you want feedback on?

No

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
