### PR TITLE
Add Option to Run Features in Subtests

### DIFF
--- a/internal/flags/options.go
+++ b/internal/flags/options.go
@@ -66,6 +66,11 @@ type Options struct {
 	// TestingT runs scenarios as subtests.
 	TestingT *testing.T
 
+	// FeaturesInSubtests runs features as subtests.
+	// This will override TestingT option and scenatios will be
+	// run as subtests of the features.
+	FeaturesInSubtests *testing.T
+
 	// FeatureContents allows passing in each feature manually
 	// where the contents of each feature is stored as a byte slice
 	// in a map entry

--- a/run_test.go
+++ b/run_test.go
@@ -544,7 +544,7 @@ func Test_AllFeaturesRun(t *testing.T) {
 	assert.Equal(t, expected, actualOutput)
 }
 
-func Test_AllFeaturesRunAsSubtests(t *testing.T) {
+func Test_AllScenariosRunAsSubtests(t *testing.T) {
 	const concurrency = 100
 	const noRandomFlag = 0
 	const format = "progress"
@@ -571,6 +571,41 @@ func Test_AllFeaturesRunAsSubtests(t *testing.T) {
 			Paths:       []string{"features"},
 			Randomize:   noRandomFlag,
 			TestingT:    t,
+		},
+		InitializeScenario,
+	)
+
+	assert.Equal(t, exitSuccess, actualStatus)
+	assert.Equal(t, expected, actualOutput)
+}
+
+func Test_AllFeaturesAndScenariosRunAsSubtests(t *testing.T) {
+	const concurrency = 100
+	const noRandomFlag = 0
+	const format = "progress"
+
+	const expected = `...................................................................... 70
+...................................................................... 140
+...................................................................... 210
+...................................................................... 280
+...................................................................... 350
+...................................................................... 420
+...                                                                    423
+
+
+108 scenarios (108 passed)
+423 steps (423 passed)
+0s
+`
+
+	actualStatus, actualOutput := testRunWithOptions(
+		t,
+		Options{
+			Format:             format,
+			Concurrency:        concurrency,
+			Paths:              []string{"features"},
+			Randomize:          noRandomFlag,
+			FeaturesInSubtests: t,
 		},
 		InitializeScenario,
 	)


### PR DESCRIPTION
### 🤔 What's changed?

Add Option to run features in separate subtests.

### ⚡️ What's your motivation? 

Usually, scenarios are grouped logically in feature files. Adding this options helps test report readability when running multiple feature files each containing multiple scenarios.

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?

Comparing the test results from the added unit tests versus the one running all scenarios.

### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
