### PR TITLE
Print step declaration line instead of handler declaration line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 ## Unreleased
 
 - fix(formatter): On concurrent execution, execute formatter at end of Scenario - ([645](https://github.com/cucumber/godog/pull/645) - [tigh-latte](https://github.com/tigh-latte))
+- Pretty printing results now prints the line where the step is declared instead of the line where the handler is declared. ([668](https://github.com/cucumber/godog/pull/668) - [spencerc](https://github.com/SpencerC))
 
 ## [v0.15.0]
 

--- a/internal/formatters/fmt.go
+++ b/internal/formatters/fmt.go
@@ -78,9 +78,7 @@ func mustConvertStringToInt(s string) int {
 func DefinitionID(sd *models.StepDefinition) string {
 	ptr := sd.HandlerValue.Pointer()
 	f := runtime.FuncForPC(ptr)
-	file, line := f.FileLine(ptr)
-	dir := filepath.Dir(file)
-
+	dir := filepath.Dir(sd.File)
 	fn := strings.Replace(f.Name(), dir, "", -1)
 	var parts []string
 	for _, gr := range matchFuncDefRef.FindAllStringSubmatch(fn, -1) {
@@ -100,7 +98,7 @@ func DefinitionID(sd *models.StepDefinition) string {
 		fn = strings.Replace(fn, "..", ".", -1)
 	}
 
-	return fmt.Sprintf("%s:%d -> %s", filepath.Base(file), line, fn)
+	return fmt.Sprintf("%s:%d -> %s", filepath.Base(sd.File), sd.Line, fn)
 }
 
 var matchFuncDefRef = regexp.MustCompile(`\(([^\)]+)\)`)

--- a/internal/models/stepdef.go
+++ b/internal/models/stepdef.go
@@ -27,6 +27,8 @@ type StepDefinition struct {
 
 	Args         []interface{}
 	HandlerValue reflect.Value
+	File         string
+	Line         int
 
 	// multistep related
 	Nested    bool

--- a/suite.go
+++ b/suite.go
@@ -258,6 +258,8 @@ func (s *suite) runStep(ctx context.Context, pickle *Scenario, step *Step, scena
 				},
 				Args:         match.Args,
 				HandlerValue: match.HandlerValue,
+				File:         match.File,
+				Line:         match.Line,
 				Nested:       match.Nested,
 				Undefined:    undef,
 			}
@@ -530,6 +532,8 @@ func (s *suite) matchStepTextAndType(text string, stepType messages.PickleStepTy
 				},
 				Args:         args,
 				HandlerValue: h.HandlerValue,
+				File:         h.File,
+				Line:         h.Line,
 				Nested:       h.Nested,
 			}
 

--- a/test_context.go
+++ b/test_context.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"runtime"
+
+	messages "github.com/cucumber/messages/go/v21"
 
 	"github.com/cucumber/godog/formatters"
 	"github.com/cucumber/godog/internal/builder"
 	"github.com/cucumber/godog/internal/flags"
 	"github.com/cucumber/godog/internal/models"
-	messages "github.com/cucumber/messages/go/v21"
 )
 
 // GherkinDocument represents gherkin document.
@@ -341,6 +343,10 @@ func (ctx ScenarioContext) stepWithKeyword(expr interface{}, stepFunc interface{
 		HandlerValue: reflect.ValueOf(stepFunc),
 		Nested:       isNested,
 	}
+
+	// Get the file and line number of the call that created this step with a
+	// call to one of the Step, Given, When, or Then wrappers.
+	_, def.File, def.Line, _ = runtime.Caller(2)
 
 	// stash the step
 	ctx.suite.steps = append(ctx.suite.steps, def)


### PR DESCRIPTION
### 🤔 What's changed?

Pretty printing results now prints the line where the step is declared instead of the line where the handler is declared.

### ⚡️ What's your motivation? 

Printing the file and line number of handlers often produces meaningless results. For example:
* Anonymous functions: `ctx.Step("...", func () {...})` always point to line 0: `some_file_test.go:0`
* Instance receiver methods: `ctx.Step("...", instance.Method)` always point to: `<autogenerated>:1`. 

Pointing to the step declaration does require an additional click to get to the handler code, so an alternative approach would be to improve the reflection process to do a better job locating the handler code.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

This might be considered breaking if anyone is relying on the previous specific log format in CI tasks.

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
