### PR TITLE
Update honnef.co/go/tools/cmd/staticcheck version in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ check-go-version:
 test: check-go-version
 	@echo "running all tests"
 	@go fmt ./...
-	@go run honnef.co/go/tools/cmd/staticcheck@v0.4.7 github.com/cucumber/godog
-	@go run honnef.co/go/tools/cmd/staticcheck@v0.4.7 github.com/cucumber/godog/cmd/godog
+	@go run honnef.co/go/tools/cmd/staticcheck@v0.5.1 github.com/cucumber/godog
+	@go run honnef.co/go/tools/cmd/staticcheck@v0.5.1 github.com/cucumber/godog/cmd/godog
 	go vet ./...
 	go test -race ./...
 	go run ./cmd/godog -f progress -c 4


### PR DESCRIPTION
### 🤔 What's changed?

Updated the dependency for `honnef.co/go/tools` in the `Makefile` from version `v0.4.7` to `v0.5.1`. This update resolves a panic issue that occurs when running `make test` with Go 1.23 or later, which introduced changes in range over function types.

### ⚡️ What's your motivation?

The previous version of the `honnef.co/go/tools` library (`v0.4.7`) is incompatible with Go 1.23+ due to changes in how `range` is handled for function types with signatures like `func(T comparable) bool`. This resulted in the following runtime error when running `make test` : 
```
running all tests
panic: Cannot range over: func(yield func(E) bool)

goroutine 209 [running]:
honnef.co/go/tools/go/ir.(*builder).rangeStmt(0xc000e93a60, 0xc000e24c80, 0xc0002280c0, 0x0, {0x1ec09d0, 0xc0002280c0})
        /Users/ray/go/pkg/mod/honnef.co/go/tools@v0.4.7/go/ir/builder.go:2225 +0x894
honnef.co/go/tools/go/ir.(*builder).stmt(0xc000e93a60, 0xc000e24c80, {0x1ec2d78?, 0xc0002280c0?})
        /Users/ray/go/pkg/mod/honnef.co/go/tools@v0.4.7/go/ir/builder.go:2438 +0x20a
honnef.co/go/tools/go/ir.(*builder).stmtList(...)
        /Users/ray/go/pkg/mod/honnef.co/go/tools@v0.4.7/go/ir/builder.go:859
honnef.co/go/tools/go/ir.(*builder).stmt(0xc000e93a60, 0xc000e24c80, {0x1ec29b8?, 0xc0001b0e70?})
        /Users/ray/go/pkg/mod/honnef.co/go/tools@v0.4.7/go/ir/builder.go:2396 +0x1415
honnef.co/go/tools/go/ir.(*builder).buildFunction(0xc000e93a60, 0xc000e24c80)
        /Users/ray/go/pkg/mod/honnef.co/go/tools@v0.4.7/go/ir/builder.go:2508 +0x417
honnef.co/go/tools/go/ir.(*builder).buildFuncDecl(0xc000e93a60, 0xc000510a20, 0xc0001b0ea0)
        /Users/ray/go/pkg/mod/honnef.co/go/tools@v0.4.7/go/ir/builder.go:2545 +0x189
honnef.co/go/tools/go/ir.(*Package).build(0xc000510a20)
        /Users/ray/go/pkg/mod/honnef.co/go/tools@v0.4.7/go/ir/builder.go:2649 +0xb46
sync.(*Once).doSlow(0xc000bf00e0?, 0xc0002a5bc0?)
        /usr/local/Cellar/go/1.23.4/libexec/src/sync/once.go:76 +0xb4
sync.(*Once).Do(...)
        /usr/local/Cellar/go/1.23.4/libexec/src/sync/once.go:67
honnef.co/go/tools/go/ir.(*Package).Build(...)
        /Users/ray/go/pkg/mod/honnef.co/go/tools@v0.4.7/go/ir/builder.go:2567
honnef.co/go/tools/internal/passes/buildir.run(0xc0002c6ea0)
        /Users/ray/go/pkg/mod/honnef.co/go/tools@v0.4.7/internal/passes/buildir/buildir.go:86 +0x18b
honnef.co/go/tools/lintcmd/runner.(*analyzerRunner).do(0xc000d8a8a0, {0x1ec54d8?, 0xc000a98fa0})
        /Users/ray/go/pkg/mod/honnef.co/go/tools@v0.4.7/lintcmd/runner/runner.go:992 +0x71b
honnef.co/go/tools/lintcmd/runner.genericHandle({0x1ec54d8, 0xc000a98fa0}, {0x1ec54d8?, 0xc000a98f00?}, 0xc000d80e70, 0xc00042b6b0, 0xc000bfa250)
        /Users/ray/go/pkg/mod/honnef.co/go/tools@v0.4.7/lintcmd/runner/runner.go:817 +0x11f
created by honnef.co/go/tools/lintcmd/runner.(*subrunner).runAnalyzers in goroutine 121
        /Users/ray/go/pkg/mod/honnef.co/go/tools@v0.4.7/lintcmd/runner/runner.go:1061 +0x6a6
exit status 2
make: *** [test] Error 1
```


Upgrading to `v0.5.1` resolves this issue and ensures compatibility with the latest Go versions.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
