### PR TITLE
Add parallel worker support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org).
 This document is formatted according to the principles of [Keep A CHANGELOG](http://keepachangelog.com).
 
 ## Unreleased
+- Add parallel worker support - ([678](https://github.com/cucumber/godog/pull/678) - [skiz](https://github.com/skiz))
 
 ### Added
 - Step text is added to "step is undefined" error - ([669](https://github.com/cucumber/godog/pull/669) - [vearutop](https://github.com/vearutop))

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -46,6 +46,6 @@ built-in formatters are:
 specify SEED to reproduce the shuffling from a previous run
   --random=5738`)
 	flagSet.Lookup(prefix + "random").NoOptDefVal = "-1"
-	flagSet.Uint8Var(&opts.Mod, prefix+"mod", opts.Mod, "split secnarios based on a modulus calculation. Used in conjunction with --target")
-	flagSet.Uint8Var(&opts.Target, prefix+"target", opts.Target, "split secnarios based on a modulus calculation. Used in conjunction with --mod")
+	flagSet.IntVar(&opts.Mod, prefix+"mod", opts.Mod, "split secnarios based on a modulus calculation. Used in conjunction with --target")
+	flagSet.IntVar(&opts.Target, prefix+"target", opts.Target, "split secnarios based on a modulus calculation. Used in conjunction with --mod")
 }

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -46,4 +46,6 @@ built-in formatters are:
 specify SEED to reproduce the shuffling from a previous run
   --random=5738`)
 	flagSet.Lookup(prefix + "random").NoOptDefVal = "-1"
+	flagSet.Uint8Var(&opts.Mod, prefix+"mod", opts.Mod, "split secnarios based on a modulus calculation. Used in conjunction with --target")
+	flagSet.Uint8Var(&opts.Target, prefix+"target", opts.Target, "split secnarios based on a modulus calculation. Used in conjunction with --mod")
 }

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -25,6 +25,8 @@ func Test_BindFlagsShouldRespectFlagDefaults(t *testing.T) {
 	assert.False(t, opts.Strict)
 	assert.False(t, opts.NoColors)
 	assert.Equal(t, int64(0), opts.Randomize)
+	assert.Equal(t, uint8(0), opts.Mod)
+	assert.Equal(t, uint8(0), opts.Target)
 }
 
 func Test_BindFlagsShouldRespectFlagOverrides(t *testing.T) {
@@ -51,6 +53,8 @@ func Test_BindFlagsShouldRespectFlagOverrides(t *testing.T) {
 		"--optOverrides.strict=false",
 		"--optOverrides.no-colors=false",
 		"--optOverrides.random=2",
+		"--optOverrides.mod=5",
+		"--optOverrides.target=2",
 	})
 
 	assert.Equal(t, "junit", opts.Format)
@@ -61,4 +65,6 @@ func Test_BindFlagsShouldRespectFlagOverrides(t *testing.T) {
 	assert.False(t, opts.Strict)
 	assert.False(t, opts.NoColors)
 	assert.Equal(t, int64(2), opts.Randomize)
+	assert.Equal(t, uint8(5), opts.Mod)
+	assert.Equal(t, uint8(2), opts.Target)
 }

--- a/internal/flags/options.go
+++ b/internal/flags/options.go
@@ -80,6 +80,25 @@ type Options struct {
 
 	// ShowHelp enables suite to show CLI flags usage help and exit.
 	ShowHelp bool
+
+	// Mod is used to split secnarios based on a modulus calculation to enable running
+	// the suite across concurrent worker nodes.
+	//
+	// This feature is compatible with random seeds when all workers use the same seed.
+	//
+	// The default value is 0 which runs every scenario.
+	//
+	// Worker 1: --mod 2 --target 0 # run scenarios 0,2,4,6
+	// Worker 2: --mod 2 --target 1 # run scenarios 1,3,5,7
+	//
+	Mod uint8
+
+	// Target is used in conjunction with Mod to split scenarios based on a modulus.
+	// See `Mod`` for more information.
+	//
+	// The default value is 0 which runs every scenario.
+	//
+	Target uint8
 }
 
 type Feature struct {

--- a/internal/flags/options.go
+++ b/internal/flags/options.go
@@ -91,14 +91,12 @@ type Options struct {
 	// Worker 1: --mod 2 --target 0 # run scenarios 0,2,4,6
 	// Worker 2: --mod 2 --target 1 # run scenarios 1,3,5,7
 	//
-	Mod uint8
+	Mod int
 
-	// Target is used in conjunction with Mod to split scenarios based on a modulus.
+	// Target is used in conjunction with Mod to run a subset of scenarios based on a modulus.
 	// See `Mod`` for more information.
 	//
-	// The default value is 0 which runs every scenario.
-	//
-	Target uint8
+	Target int
 }
 
 type Feature struct {

--- a/run.go
+++ b/run.go
@@ -52,6 +52,9 @@ type runner struct {
 
 	storage *storage.Storage
 	fmt     Formatter
+
+	mod    int
+	target int
 }
 
 func (r *runner) concurrent(rate int) (failed bool) {
@@ -85,7 +88,12 @@ func (r *runner) concurrent(rate int) (failed bool) {
 	}
 
 	queue := make(chan int, rate)
-	for _, ft := range r.features {
+	for fid, ft := range r.features {
+
+		if r.mod > 0 && fid%r.mod != r.target {
+			continue
+		}
+
 		pickles := make([]*messages.Pickle, len(ft.Pickles))
 		if r.randomSeed != 0 {
 			r := rand.New(rand.NewSource(r.randomSeed))
@@ -283,6 +291,8 @@ func runWithOptions(suiteName string, runner runner, opt Options) int {
 	runner.strict = opt.Strict
 	runner.defaultContext = opt.DefaultContext
 	runner.testingT = opt.TestingT
+	runner.mod = opt.Mod
+	runner.target = opt.Target
 
 	// store chosen seed in environment, so it could be seen in formatter summary report
 	os.Setenv("GODOG_SEED", strconv.FormatInt(runner.randomSeed, 10))

--- a/run_test.go
+++ b/run_test.go
@@ -355,6 +355,39 @@ Feature: run features from bytes
 	assert.Equal(t, exitSuccess, status)
 }
 
+func Test_RunsWithModTargetOptions(t *testing.T) {
+	type ModTest struct {
+		Mod               int
+		Target            int
+		ExpectedScenarios int
+	}
+
+	blockTest := []*ModTest{
+		{Mod: 0, Target: 0, ExpectedScenarios: 108},
+		{Mod: 3, Target: 0, ExpectedScenarios: 17},
+		{Mod: 3, Target: 1, ExpectedScenarios: 49},
+		{Mod: 3, Target: 2, ExpectedScenarios: 42},
+		{Mod: 5, Target: 4, ExpectedScenarios: 15},
+	}
+
+	for _, bt := range blockTest {
+		actualStatus, actualOutput := testRunWithOptions(
+			t,
+			Options{
+				Format:   "progress",
+				Paths:    []string{"features"},
+				Mod:      bt.Mod,
+				Target:   bt.Target,
+				TestingT: t,
+			},
+			InitializeScenario,
+		)
+
+		assert.Equal(t, exitSuccess, actualStatus)
+		assert.Contains(t, actualOutput, fmt.Sprintf("scenarios (%d passed)", bt.ExpectedScenarios))
+	}
+}
+
 func bufErrorPipe(t *testing.T) (io.ReadCloser, func()) {
 	stderr := os.Stderr
 	r, w, err := os.Pipe()


### PR DESCRIPTION
### 🤔 What's changed?

Added support for running a subset of features across multiple workers in parallel via flags.

* Adds `--mod` and `--target` flags for splitting tests.

We can split the requests across multiple instances and avoid having to manually tag tests to run on each worker. So we split them across 5 workers.  We can apply command line arguments when starting the tests so each worker runs the Nth feature.  

Worker 1:  `--mod=5 --target=0`
Worker 2:  `--mod=5 --target=1`
Worker 3:  `--mod=5 --target=2`
Worker 4:  `--mod=5 --target=3`
Worker 5:  `--mod=5 --target=4`

This only affects the actual run of the test, so random seeds should continue to work as expected if they are constant across the workers for a given test suite run.


### ⚡️ What's your motivation? 

You have 200 features but they need to run one at a time due to design constraints.  You cannot run them concurrently on the same machine due to service dependencies and their states. You don't want to manually manage tagging tests to run on a specific worker.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
