### PR TITLE
Replace deprecated `::set-output`

### DIFF
--- a/.github/workflows/gorelease.yml
+++ b/.github/workflows/gorelease.yml
@@ -33,7 +33,7 @@ jobs:
           OUTPUT=$(gorelease 2>&1 || exit 0)
           echo "${OUTPUT}"
           OUTPUT="${OUTPUT//$'\n'/%0A}"
-          echo "::set-output name=report::$OUTPUT"
+          echo "report=$OUTPUT" >> $GITHUB_OUTPUT
       - name: Comment Report
         continue-on-error: true
         uses: marocchino/sticky-pull-request-comment@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 ### Added
 - Step text is added to "step is undefined" error - ([669](https://github.com/cucumber/godog/pull/669) - [vearutop](https://github.com/vearutop))
 
+### Changed
+- Replace deprecated `::set-output` - ([681](https://github.com/cucumber/godog/pull/681) - [nodeg](https://github.com/nodeg))
+
 ### Fixed
 - fix(errors): fix(errors): Fix expected Step argument count for steps with `context.Context` ([679](https://github.com/cucumber/godog/pull/679) - [tigh-latte](https://github.com/tigh-latte))
 - fix(formatter): On concurrent execution, execute formatter at end of Scenario - ([645](https://github.com/cucumber/godog/pull/645) - [tigh-latte](https://github.com/tigh-latte))


### PR DESCRIPTION

### 🤔 What's changed?

As per the deprecation warning and explanation at https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

### ⚡️ What's your motivation? 

See https://github.com/cucumber/common/issues/2150

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

Is the changelog entry fine this way?

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
