### PR TITLE
fix: verify dogT exists in the context before using it

### DIFF
--- a/suite.go
+++ b/suite.go
@@ -159,7 +159,9 @@ func (s *suite) runStep(ctx context.Context, pickle *Scenario, step *Step, scena
 
 		// Check for any calls to Fail on dogT
 		if err == nil {
-			err = getTestingT(ctx).isFailed()
+			if t := getTestingT(ctx); t != nil {
+				err = t.isFailed()
+			}
 		}
 
 		status := StepUndefined


### PR DESCRIPTION
getTestingT(ctx) can return a nil pointer (if there is no dogT in the context) in this case a segfault causes the whole test harness to fail. By verifying whether there is a dogT in the context, the test can continue.

### 🤔 What's changed?

Added a check to verify whether the dogT was available in the context before querying its state.

### ⚡️ What's your motivation? 

While using godog (After updating from v0.12.x to v0.15.0) our test harness ran into a segfault. The cause of the segfault was a nil pointer deference that is verified to be fixed with the proposed change.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
