### PR TITLE
fix: Validate the handler function param types when registering steps.

### DIFF
--- a/internal/models/stepdef.go
+++ b/internal/models/stepdef.go
@@ -12,7 +12,7 @@ import (
 	"github.com/cucumber/godog/formatters"
 )
 
-var typeOfBytes = reflect.TypeOf([]byte(nil))
+var TypeOfBytes = reflect.TypeOf([]byte(nil))
 
 // matchable errors
 var (
@@ -35,7 +35,7 @@ type StepDefinition struct {
 	Undefined []string
 }
 
-var typeOfContext = reflect.TypeOf((*context.Context)(nil)).Elem()
+var TypeOfContext = reflect.TypeOf((*context.Context)(nil)).Elem()
 
 // Run a step with the matched arguments using reflect
 // Returns one of ...
@@ -46,7 +46,7 @@ func (sd *StepDefinition) Run(ctx context.Context) (context.Context, interface{}
 
 	typ := sd.HandlerValue.Type()
 	numIn := typ.NumIn()
-	hasCtxIn := numIn > 0 && typ.In(0).Implements(typeOfContext)
+	hasCtxIn := numIn > 0 && typ.In(0).Implements(TypeOfContext)
 	ctxOffset := 0
 
 	if hasCtxIn {
@@ -221,7 +221,7 @@ func (sd *StepDefinition) Run(ctx context.Context) (context.Context, interface{}
 			}
 		case reflect.Slice:
 			switch param {
-			case typeOfBytes:
+			case TypeOfBytes:
 				s, err := sd.shouldBeString(i)
 				if err != nil {
 					return ctx, err

--- a/test_context_test.go
+++ b/test_context_test.go
@@ -97,26 +97,25 @@ func TestScenarioContext_Step(t *testing.T) {
 	}
 }
 func okValidParams(
-	_ int, _ int64, _ int32, _ int16, _ int8,
-	_ uint, _ uint64, _ uint32, _ uint16, _ uint8,
-	_ string,
-	_ float64, _ float32,
-	_ *messages.PickleDocString, _ *messages.PickleTable,
-	_ []byte) {
+	int, int64, int32, int16, int8,
+	uint, uint64, uint32, uint16, uint8,
+	string, float64, float32, []byte,
+	*messages.PickleDocString, *messages.PickleTable,
+) {
 }
-func okVoidResult()                                                   {}
-func okErrorResult() error                                            { return nil }
-func okStepsResult() Steps                                            { return nil }
-func okContextErrorResult() (context.Context, error)                  { return nil, nil }
-func nokInvalidParamCtxNotFirst(_ int, _ context.Context)             {}
-func nokInvalidParamStruct(_ struct{})                                {}
-func nokInvalidParamPickleDocStringStruct(_ messages.PickleDocString) {}
-func nokInvalidParamPickleStepArgumentStruct(_ messages.PickleTable)  {}
-func nokInvalidParamInvalidSliceType([]string)                        {}
-func nokInvalidParamUnsupportedPointer(*int)                          {}
-func nokSliceStringResult() []string                                  { return nil }
-func nokLimitCase3() (string, int, error)                             { return "", 0, nil }
-func nokLimitCase5() (int, int, int, int, error)                      { return 0, 0, 0, 0, nil }
-func nokInvalidReturnInterfaceType() interface{}                      { return 0 }
-func nokInvalidReturnSliceType() []int                                { return nil }
-func nokInvalidReturnOtherType() chan int                             { return nil }
+func okVoidResult()                                                 {}
+func okErrorResult() error                                          { return nil }
+func okStepsResult() Steps                                          { return nil }
+func okContextErrorResult() (context.Context, error)                { return nil, nil }
+func nokInvalidParamCtxNotFirst(int, context.Context)               {}
+func nokInvalidParamStruct(struct{})                                {}
+func nokInvalidParamPickleDocStringStruct(messages.PickleDocString) {}
+func nokInvalidParamPickleStepArgumentStruct(messages.PickleTable)  {}
+func nokInvalidParamInvalidSliceType([]string)                      {}
+func nokInvalidParamUnsupportedPointer(*int)                        {}
+func nokSliceStringResult() []string                                { return nil }
+func nokLimitCase3() (string, int, error)                           { return "", 0, nil }
+func nokLimitCase5() (int, int, int, int, error)                    { return 0, 0, 0, 0, nil }
+func nokInvalidReturnInterfaceType() interface{}                    { return 0 }
+func nokInvalidReturnSliceType() []int                              { return nil }
+func nokInvalidReturnOtherType() chan int                           { return nil }

--- a/test_context_test.go
+++ b/test_context_test.go
@@ -2,6 +2,7 @@ package godog
 
 import (
 	"context"
+	messages "github.com/cucumber/messages/go/v21"
 	"regexp"
 	"testing"
 
@@ -32,6 +33,8 @@ func TestScenarioContext_Step(t *testing.T) {
 			f: func() { ctx.Step(".*", okStepsResult) }},
 		{n: "ScenarioContext should accept steps handler with (Context, error) return",
 			f: func() { ctx.Step(".*", okContextErrorResult) }},
+		{n: "ScenarioContext should accept steps handler with valid params",
+			f: func() { ctx.Step(".*", okValidParams) }},
 	} {
 		t.Run(c.n, func(t *testing.T) {
 			assert.NotPanics(t, c.f)
@@ -56,6 +59,22 @@ func TestScenarioContext_Step(t *testing.T) {
 			p: "expecting expr to be a *regexp.Regexp or a string or []byte, got type: int",
 			f: func() { ctx.Step(1251, okVoidResult) }},
 
+		{n: "ScenarioContext should panic if step handler params include context.Context, but context.Context is not the first parameter",
+			p: "func has unsupported parameter type: the parameter 1 type interface is not supported",
+			f: func() { ctx.Step(".*", nokInvalidParamCtxNotFirst) }},
+		{n: "ScenarioContext should panic if step handler params include struct",
+			p: "func has unsupported parameter type: the parameter 0 type struct is not supported",
+			f: func() { ctx.Step(".*", nokInvalidParamStruct) }},
+		{n: "ScenarioContext should panic if step handler params include messages.PickleStepArgument struct instead of pointer",
+			p: "func has unsupported parameter type: the parameter 0 type struct is not supported",
+			f: func() { ctx.Step(".*", nokInvalidParamPickleStepArgumentStruct) }},
+		{n: "ScenarioContext should panic if step handler params include messages.PickleDocString struct instead of pointer",
+			p: "func has unsupported parameter type: the parameter 0 type struct is not supported",
+			f: func() { ctx.Step(".*", nokInvalidParamPickleDocStringStruct) }},
+		{n: "ScenarioContext should panic if step handler params include unsupported slice parameter type",
+			p: "func has unsupported parameter type: the slice parameter 0 type []string is not supported",
+			f: func() { ctx.Step(".*", nokInvalidParamInvalidSliceType) }},
+
 		{n: "ScenarioContext should panic if step return type is []string",
 			p: "expected handler to return one of error or context.Context or godog.Steps or (context.Context, error), but got: []string",
 			f: func() { ctx.Step(".*", nokSliceStringResult) }},
@@ -74,14 +93,26 @@ func TestScenarioContext_Step(t *testing.T) {
 		})
 	}
 }
-
-func okVoidResult()                                  {}
-func okErrorResult() error                           { return nil }
-func okStepsResult() Steps                           { return nil }
-func okContextErrorResult() (context.Context, error) { return nil, nil }
-func nokSliceStringResult() []string                 { return nil }
-func nokLimitCase3() (string, int, error)            { return "", 0, nil }
-func nokLimitCase5() (int, int, int, int, error)     { return 0, 0, 0, 0, nil }
-func nokInvalidReturnInterfaceType() interface{}     { return 0 }
-func nokInvalidReturnSliceType() []int               { return nil }
-func nokInvalidReturnOtherType() chan int            { return nil }
+func okValidParams(
+	_ int, _ int64, _ int32, _ int16, _ int8,
+	_ uint, _ uint64, _ uint32, _ uint16, _ uint8,
+	_ string,
+	_ float64, _ float32,
+	_ *messages.PickleDocString, _ *messages.PickleTable,
+	_ []byte) {
+}
+func okVoidResult()                                                   {}
+func okErrorResult() error                                            { return nil }
+func okStepsResult() Steps                                            { return nil }
+func okContextErrorResult() (context.Context, error)                  { return nil, nil }
+func nokInvalidParamCtxNotFirst(_ int, _ context.Context)             {}
+func nokInvalidParamStruct(_ struct{})                                {}
+func nokInvalidParamPickleDocStringStruct(_ messages.PickleDocString) {}
+func nokInvalidParamPickleStepArgumentStruct(_ messages.PickleTable)  {}
+func nokInvalidParamInvalidSliceType([]string)                        {}
+func nokSliceStringResult() []string                                  { return nil }
+func nokLimitCase3() (string, int, error)                             { return "", 0, nil }
+func nokLimitCase5() (int, int, int, int, error)                      { return 0, 0, 0, 0, nil }
+func nokInvalidReturnInterfaceType() interface{}                      { return 0 }
+func nokInvalidReturnSliceType() []int                                { return nil }
+func nokInvalidReturnOtherType() chan int                             { return nil }

--- a/test_context_test.go
+++ b/test_context_test.go
@@ -74,6 +74,9 @@ func TestScenarioContext_Step(t *testing.T) {
 		{n: "ScenarioContext should panic if step handler params include unsupported slice parameter type",
 			p: "func has unsupported parameter type: the slice parameter 0 type []string is not supported",
 			f: func() { ctx.Step(".*", nokInvalidParamInvalidSliceType) }},
+		{n: "ScenarioContext should panic if step handler params include unsupported pointer parameter type",
+			p: "func has unsupported parameter type: the data type of parameter 0 type *int is not supported",
+			f: func() { ctx.Step(".*", nokInvalidParamUnsupportedPointer) }},
 
 		{n: "ScenarioContext should panic if step return type is []string",
 			p: "expected handler to return one of error or context.Context or godog.Steps or (context.Context, error), but got: []string",
@@ -110,6 +113,7 @@ func nokInvalidParamStruct(_ struct{})                                {}
 func nokInvalidParamPickleDocStringStruct(_ messages.PickleDocString) {}
 func nokInvalidParamPickleStepArgumentStruct(_ messages.PickleTable)  {}
 func nokInvalidParamInvalidSliceType([]string)                        {}
+func nokInvalidParamUnsupportedPointer(*int)                          {}
 func nokSliceStringResult() []string                                  { return nil }
 func nokLimitCase3() (string, int, error)                             { return "", 0, nil }
 func nokLimitCase5() (int, int, int, int, error)                      { return 0, 0, 0, 0, nil }


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

<!-- Describe your changes in detail -->
It checks the step handler params while registering the steps.

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->
There is a FIXME tag in test_context.go file and I think I can fix it.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)
- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->
I think we should have different error message when step registering/run because the `context.Context` param is in a wrong place. So probably it would be a good idea to fix it in another pr, wondering whether I should fix it in a new pr.

for example: 
when there is a handler like this:

```golang
func nokInvalidParamCtxNotFirst(_ int, _ context.Context){}
```

Maybe we can panic with

```golang
fmt.Sprintf("%s: the data type of parameter %d context.Context should be the first param", models.ErrUnsupportedParameterType, i)
```

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
