### PR TITLE
fix: prevent panic in cucumber JSON formatter on stopOnFailure

### DIFF
--- a/internal/formatters/fmt_cucumber_test.go
+++ b/internal/formatters/fmt_cucumber_test.go
@@ -1,0 +1,53 @@
+package formatters_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/cucumber/godog"
+)
+
+func TestCucumberFormatterStopOnFirstFailure(t *testing.T) {
+	featureFile := "formatter-tests/features/stop_on_first_failure.feature"
+
+	var buf bytes.Buffer
+	opts := godog.Options{
+		Format:        "cucumber",
+		Paths:         []string{featureFile},
+		Output:        &buf,
+		Strict:        true,
+		StopOnFailure: true,
+	}
+
+	suite := godog.TestSuite{
+		Name: "Cucumber - Ensure JSON report is produced when StopOnFailure is set",
+		ScenarioInitializer: func(sc *godog.ScenarioContext) {
+			setupStopOnFailureSteps(sc)
+		},
+		Options: &opts,
+	}
+
+	if status := suite.Run(); status != 1 {
+		t.Fatalf("expected status 1, but got %d", status)
+	}
+
+	var features []map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &features); err != nil {
+		t.Fatalf("failed to parse cucumber: %v\noutput:\n%s", err, buf.String())
+	}
+
+	if len(features) != 1 {
+		t.Fatalf("expected exactly one feature, got %d", len(features))
+	}
+
+	elements := features[0]["elements"].([]interface{})
+	if len(elements) != 2 {
+		t.Fatalf("expected two scenarios, got %d", len(elements))
+	}
+
+	second := elements[1].(map[string]interface{})
+	if _, ok := second["steps"]; ok { // stopOnFailure prevents steps from being added
+		t.Fatalf("expected second scenario to have no steps, but got %v", second["steps"])
+	}
+}

--- a/internal/formatters/formatter-tests/cucumber/stop_on_first_failure
+++ b/internal/formatters/formatter-tests/cucumber/stop_on_first_failure
@@ -1,0 +1,92 @@
+[
+    {
+        "uri": "formatter-tests/features/stop_on_first_failure.feature",
+        "id": "stop-on-first-failure",
+        "keyword": "Feature",
+        "name": "Stop on first failure",
+        "description": "",
+        "line": 1,
+        "elements": [
+            {
+                "id": "stop-on-first-failure;first-scenario---should-run-and-fail",
+                "keyword": "Scenario",
+                "name": "First scenario - should run and fail",
+                "description": "",
+                "line": 3,
+                "type": "scenario",
+                "steps": [
+                    {
+                        "keyword": "Given ",
+                        "name": "a passing step",
+                        "line": 4,
+                        "match": {
+                            "location": "fmt_output_test.go:XXX"
+                        },
+                        "result": {
+                            "status": "passed",
+                            "duration": 0
+                        }
+                    },
+                    {
+                        "keyword": "When ",
+                        "name": "a failing step",
+                        "line": 5,
+                        "match": {
+                            "location": "fmt_output_test.go:XXX"
+                        },
+                        "result": {
+                            "status": "failed",
+                            "error_message": "step failed",
+                            "duration": 0
+                        }
+                    },
+                    {
+                        "keyword": "Then ",
+                        "name": "a passing step",
+                        "line": 6,
+                        "match": {
+                            "location": "fmt_output_test.go:XXX"
+                        },
+                        "result": {
+                            "status": "skipped"
+                        }
+                    }
+                ]
+            },
+            {
+                "id": "stop-on-first-failure;second-scenario---should-be-skipped",
+                "keyword": "Scenario",
+                "name": "Second scenario - should be skipped",
+                "description": "",
+                "line": 8,
+                "type": "scenario",
+                "steps": [
+                    {
+                        "keyword": "Given ",
+                        "name": "a passing step",
+                        "line": 9,
+                        "match": {
+                            "location": "fmt_output_test.go:XXX"
+                        },
+                        "result": {
+                            "status": "passed",
+                            "duration": 0
+                        }
+                    },
+                    {
+                        "keyword": "Then ",
+                        "name": "a passing step",
+                        "line": 10,
+                        "match": {
+                            "location": "fmt_output_test.go:XXX"
+                        },
+                        "result": {
+                            "status": "passed",
+                            "duration": 0
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+]


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

- Wrap access to Storage.MustGetPickleResult in the cucumber formatter so that missing PickleResults (for scenarios that never execute due to StopOnFailure) do not panic, but instead return a nil result ultimately allowing for a report output
- Add a unit test to cucumber formater (`fmt_cucumber_test.go`) to assert the changes

This PR is a follow up to [this other PR](https://github.com/cucumber/godog/pull/597)

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

I use godog for professional integration tests that run in our PR pipeline, and we rely on a report being generated for every run (both success and failure). These test suites can take up to an hour when they pass, so we enable stopOnFailure to fail fast and free up CI resources as soon as a single scenario fails.

However, when stopOnFailure is enabled and a scenario fails, the cucumber JSON formatter panics before writing the report, so we can’t collect the partial report for the scenarios that did run. This change ensures we still get a valid JSON report even when the run stops early.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
