### PR TITLE
suite: recover from panics in after-step and after-scenario hooks

### DIFF
--- a/hook_panic_test.go
+++ b/hook_panic_test.go
@@ -1,0 +1,97 @@
+package godog
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	gherkin "github.com/cucumber/gherkin/go/v26"
+	messages "github.com/cucumber/messages/go/v21"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cucumber/godog/colors"
+	"github.com/cucumber/godog/internal/formatters"
+	"github.com/cucumber/godog/internal/models"
+	"github.com/cucumber/godog/internal/storage"
+)
+
+const oneStepFeature = `
+Feature: basic
+
+  Scenario: passing scenario
+	When one
+`
+
+// Test_AfterStepHookPanic covers cucumber/godog#662: a panic in an after-step
+// hook used to escape runStep's deferred recover (which had already finished),
+// so the panic killed the worker goroutine and the run died with a stack
+// trace. The expected behaviour matches the before-step side: convert the
+// panic into a hook error attached to the failing step.
+func Test_AfterStepHookPanic(t *testing.T) {
+	const path = "any.feature"
+
+	gd, err := gherkin.ParseGherkinDocument(strings.NewReader(oneStepFeature), (&messages.Incrementing{}).NewId)
+	require.NoError(t, err)
+	gd.Uri = path
+	ft := models.Feature{GherkinDocument: gd}
+	ft.Pickles = gherkin.Pickles(*gd, path, (&messages.Incrementing{}).NewId)
+
+	var buf bytes.Buffer
+	w := colors.Uncolored(&buf)
+	r := runner{
+		fmt:      formatters.ProgressFormatterFunc("progress", w),
+		features: []*models.Feature{&ft},
+		scenarioInitializer: func(ctx *ScenarioContext) {
+			ctx.Step(`^one$`, func() error { return nil })
+			ctx.StepContext().After(func(ctx context.Context, st *Step, status StepResultStatus, err error) (context.Context, error) {
+				panic("boom from after-step hook")
+			})
+		},
+	}
+
+	r.storage = storage.NewStorage()
+	r.storage.MustInsertFeature(&ft)
+	for _, pickle := range ft.Pickles {
+		r.storage.MustInsertPickle(pickle)
+	}
+
+	failed := r.concurrent(1)
+	require.True(t, failed, "panicking after-step hook should fail the run")
+	assert.Contains(t, buf.String(), "after step hook panicked")
+}
+
+// Test_AfterScenarioHookPanic covers the same shape on the scenario hook.
+func Test_AfterScenarioHookPanic(t *testing.T) {
+	const path = "any.feature"
+
+	gd, err := gherkin.ParseGherkinDocument(strings.NewReader(oneStepFeature), (&messages.Incrementing{}).NewId)
+	require.NoError(t, err)
+	gd.Uri = path
+	ft := models.Feature{GherkinDocument: gd}
+	ft.Pickles = gherkin.Pickles(*gd, path, (&messages.Incrementing{}).NewId)
+
+	var buf bytes.Buffer
+	w := colors.Uncolored(&buf)
+	r := runner{
+		fmt:      formatters.ProgressFormatterFunc("progress", w),
+		features: []*models.Feature{&ft},
+		scenarioInitializer: func(ctx *ScenarioContext) {
+			ctx.Step(`^one$`, func() error { return nil })
+			ctx.After(func(ctx context.Context, sc *Scenario, err error) (context.Context, error) {
+				panic("boom from after-scenario hook")
+			})
+		},
+	}
+
+	r.storage = storage.NewStorage()
+	r.storage.MustInsertFeature(&ft)
+	for _, pickle := range ft.Pickles {
+		r.storage.MustInsertPickle(pickle)
+	}
+
+	failed := r.concurrent(1)
+	require.True(t, failed, "panicking after-scenario hook should fail the run")
+	assert.Contains(t, buf.String(), "after scenario hook panicked")
+}

--- a/suite.go
+++ b/suite.go
@@ -322,7 +322,7 @@ func (s *suite) runBeforeStepHooks(ctx context.Context, step *Step, err error) (
 
 func (s *suite) runAfterStepHooks(ctx context.Context, step *Step, status StepResultStatus, err error) (context.Context, error) {
 	for _, f := range s.afterStepHandlers {
-		hctx, herr := f(ctx, step, status, err)
+		hctx, herr := callAfterStepHook(f, ctx, step, status, err)
 
 		// Adding hook error to resulting error without breaking hooks loop.
 		if herr != nil {
@@ -339,6 +339,22 @@ func (s *suite) runAfterStepHooks(ctx context.Context, step *Step, status StepRe
 	}
 
 	return ctx, err
+}
+
+// callAfterStepHook invokes a single after-step hook, converting a panic into
+// an error so the remaining hooks still run and the panic doesn't escape
+// runStep's defer (which has already finished its own recover by the time
+// after-step hooks fire).
+func callAfterStepHook(f AfterStepHook, ctx context.Context, step *Step, status StepResultStatus, err error) (rctx context.Context, rerr error) {
+	defer func() {
+		if e := recover(); e != nil {
+			rerr = &traceError{
+				msg:   fmt.Sprintf("after step hook panicked: %v", e),
+				stack: callStack(),
+			}
+		}
+	}()
+	return f(ctx, step, status, err)
 }
 
 func (s *suite) runBeforeScenarioHooks(ctx context.Context, pickle *messages.Pickle) (context.Context, error) {
@@ -375,7 +391,7 @@ func (s *suite) runAfterScenarioHooks(ctx context.Context, pickle *messages.Pick
 
 	// run after scenario handlers
 	for _, f := range s.afterScenarioHandlers {
-		hctx, herr := f(ctx, pickle, err)
+		hctx, herr := callAfterScenarioHook(f, ctx, pickle, err)
 
 		// Adding hook error to resulting error without breaking hooks loop.
 		if herr != nil {
@@ -403,6 +419,20 @@ func (s *suite) runAfterScenarioHooks(ctx context.Context, pickle *messages.Pick
 	}
 
 	return ctx, err
+}
+
+// callAfterScenarioHook invokes a single after-scenario hook, converting a
+// panic into an error so the panic doesn't escape runStep's defer.
+func callAfterScenarioHook(f AfterScenarioHook, ctx context.Context, pickle *messages.Pickle, err error) (rctx context.Context, rerr error) {
+	defer func() {
+		if e := recover(); e != nil {
+			rerr = &traceError{
+				msg:   fmt.Sprintf("after scenario hook panicked: %v", e),
+				stack: callStack(),
+			}
+		}
+	}()
+	return f(ctx, pickle, err)
 }
 
 func (s *suite) maybeUndefined(ctx context.Context, text string, arg interface{}, stepType messages.PickleStepType) (context.Context, []string, error) {


### PR DESCRIPTION
A panicking after-step hook crashes the worker goroutine instead of failing the step with an error, the way the before-step side already does. The before-step hooks are inside `runStep`'s panic-recovering defer, so they're protected; the after hooks aren't — they're invoked _from_ the deferred body (`runStep:185` and `:189`), so when one of them panics, the existing recover has already run and the panic escapes:

```
panic: boom from after-step hook [recovered, repanicked]
...
github.com/cucumber/godog.(*suite).runAfterStepHooks
    /tmp/godog-fork/suite.go:325
github.com/cucumber/godog.(*suite).runStep.func1
    /tmp/godog-fork/suite.go:185
```

Wrap each after hook call in a small helper with its own defer/recover that converts the panic into a `traceError`. Same shape for `runAfterScenarioHooks`. Remaining hooks in the slice still run, and the error gets attached to the step / scenario via the existing aggregation, matching the before-step semantics.

Regression coverage:
- `Test_AfterStepHookPanic` — registers an after-step hook that panics, asserts the run fails and the failure message contains "after step hook panicked".
- `Test_AfterScenarioHookPanic` — same for after-scenario.

Both fail on master (the goroutine dies before the formatter writes anything) and pass here. `go test ./...` is clean.

Fixes #662.
