### PR TITLE
Add OpenSSF Scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
+
+
 [![#StandWithUkraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg)](https://vshymanskyy.github.io/StandWithUkraine)
 [![Build Status](https://github.com/cucumber/godog/workflows/test/badge.svg)](https://github.com/cucumber/godog/actions?query=branch%main+workflow%3Atest)
 [![PkgGoDev](https://pkg.go.dev/badge/github.com/cucumber/godog)](https://pkg.go.dev/github.com/cucumber/godog)
 [![codecov](https://codecov.io/gh/cucumber/godog/branch/master/graph/badge.svg)](https://codecov.io/gh/cucumber/godog)
-[![pull requests](https://oselvar.com/api/badge?label=pull%20requests&csvUrl=https%3A%2F%2Fraw.githubusercontent.com%2Fcucumber%2Foselvar-github-metrics%2Fmain%2Fdata%2Fcucumber%2Fgodog%2FpullRequests.csv)](https://oselvar.com/github/cucumber/oselvar-github-metrics/main/cucumber/godog)
-[![issues](https://oselvar.com/api/badge?label=issues&csvUrl=https%3A%2F%2Fraw.githubusercontent.com%2Fcucumber%2Foselvar-github-metrics%2Fmain%2Fdata%2Fcucumber%2Fgodog%2Fissues.csv)](https://oselvar.com/github/cucumber/oselvar-github-metrics/main/cucumber/godog)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/cucumber/godog/badge)](https://scorecard.dev/viewer/?uri=github.com/cucumber/godog)
 
 # Godog
 


### PR DESCRIPTION
### ⚡️ What's your motivation? 

We improved the Cucumber orgs security stance a bit. The OpenSSF Scorecard provides a way to display that stance as a number. 

Contribute to: https://github.com/cucumber/common/issues/2312

I've also removed the broken Oslvar badges.

### 🏷️ What kind of change is this?
- :book: Documentation (improvements without changing code)

### ♻️ Anything particular you want feedback on?

@vearutop up to you if you want to display it. 

Overall we also get low scores for code-review and not requiring PR's for all changes. This primarily caused by using Renovate to automatically update our dependencies. Personally, I don't think the requirements the scorecard puts down to get good marks here are worth it though for a mostly unpaid opensource project. But if you want to make improvements here you are of-course free to do so.

### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
