### PR TITLE
feat: support optional arguments for int/uint/float types

### DIFF
--- a/internal/models/stepdef.go
+++ b/internal/models/stepdef.go
@@ -189,6 +189,15 @@ func (sd *StepDefinition) Run(ctx context.Context) (context.Context, interface{}
 			}
 			values = append(values, reflect.ValueOf(float32(v)))
 		case reflect.Ptr:
+			if isOptionalKind(param.Elem().Kind()) {
+				v, err := sd.parseOptional(i, param)
+				if err != nil {
+					return ctx, err
+				}
+				values = append(values, v)
+				continue
+			}
+
 			arg := sd.Args[i]
 			switch param.Elem().String() {
 			case "messages.PickleDocString":
@@ -297,6 +306,56 @@ func (sd *StepDefinition) shouldBeString(idx int) (string, error) {
 	default:
 		return "", fmt.Errorf(`%w %d: "%v" of type "%T" to string`, ErrCannotConvert, idx, arg, arg)
 	}
+}
+
+func isOptionalKind(kind reflect.Kind) bool {
+	switch kind {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64:
+		return true
+	default:
+		return false
+	}
+}
+
+func (sd *StepDefinition) parseOptional(idx int, param reflect.Type) (reflect.Value, error) {
+	s, err := sd.shouldBeString(idx)
+	if err != nil {
+		return reflect.Value{}, err
+	}
+
+	if s == "" {
+		return reflect.Zero(param), nil
+	}
+
+	elem := param.Elem()
+	out := reflect.New(elem)
+
+	switch elem.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		v, err := strconv.ParseInt(s, 10, elem.Bits())
+		if err != nil {
+			return reflect.Value{}, fmt.Errorf(`%w %d: "%s" to *%s: %s`, ErrCannotConvert, idx, s, elem.Kind(), err)
+		}
+		out.Elem().SetInt(v)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		v, err := strconv.ParseUint(s, 10, elem.Bits())
+		if err != nil {
+			return reflect.Value{}, fmt.Errorf(`%w %d: "%s" to *%s: %s`, ErrCannotConvert, idx, s, elem.Kind(), err)
+		}
+		out.Elem().SetUint(v)
+	case reflect.Float32, reflect.Float64:
+		v, err := strconv.ParseFloat(s, elem.Bits())
+		if err != nil {
+			return reflect.Value{}, fmt.Errorf(`%w %d: "%s" to *%s: %s`, ErrCannotConvert, idx, s, elem.Kind(), err)
+		}
+		out.Elem().SetFloat(v)
+	default:
+		return reflect.Value{}, fmt.Errorf("%w: the parameter %d type %s is not supported", ErrUnsupportedParameterType, idx, param.Kind())
+	}
+
+	return out, nil
 }
 
 // GetInternalStepDefinition ...

--- a/internal/models/stepdef_test.go
+++ b/internal/models/stepdef_test.go
@@ -400,6 +400,138 @@ func TestShouldSupportFloatTypes(t *testing.T) {
 	assert.Equal(t, `cannot convert argument 1: "22222222222222222222222222222222222222222222222222222222222222222.22" to float32: strconv.ParseFloat: parsing "22222222222222222222222222222222222222222222222222222222222222222.22": value out of range`, err.(error).Error())
 }
 
+func TestShouldSupportOptionalPtrTypes(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected interface{}
+		invalid  string
+	}{
+		{"*int", "42", 42, "x"},
+		{"*int8", "42", int8(42), "x"},
+		{"*int16", "42", int16(42), "x"},
+		{"*int32", "42", int32(42), "x"},
+		{"*int64", "42", int64(42), "x"},
+		{"*uint", "42", uint(42), "x"},
+		{"*uint8", "42", uint8(42), "x"},
+		{"*uint16", "42", uint16(42), "x"},
+		{"*uint32", "42", uint32(42), "x"},
+		{"*uint64", "42", uint64(42), "x"},
+		{"*float32", "3.14", float32(3.14), "x"},
+		{"*float64", "3.14", float64(3.14), "x"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var got interface{}
+			elemType := reflect.TypeOf(c.expected)
+			ptrType := reflect.PointerTo(elemType)
+			fnType := reflect.FuncOf([]reflect.Type{ptrType}, nil, false)
+			handler := reflect.MakeFunc(fnType, func(args []reflect.Value) []reflect.Value {
+				if args[0].IsNil() {
+					got = nil
+				} else {
+					got = args[0].Elem().Interface()
+				}
+				return nil
+			}).Interface()
+
+			def := &models.StepDefinition{
+				StepDefinition: formatters.StepDefinition{Handler: handler},
+				HandlerValue:   reflect.ValueOf(handler),
+			}
+
+			// value present -> pointer to parsed value
+			def.Args = []interface{}{c.input}
+			_, err := def.Run(context.Background())
+			assert.Nil(t, err, "present value should not error")
+			assert.Equal(t, c.expected, got, "present value mismatch")
+
+			// empty capture -> nil pointer
+			got = "sentinel"
+			def.Args = []interface{}{""}
+			_, err = def.Run(context.Background())
+			assert.Nil(t, err, "empty capture should not error")
+			assert.Nil(t, got, "empty capture should yield nil")
+
+			// invalid value -> conversion error
+			def.Args = []interface{}{c.invalid}
+			_, err = def.Run(context.Background())
+			assert.True(t, errors.Is(err.(error), models.ErrCannotConvert), "invalid value should cause cannot convert error")
+		})
+	}
+}
+
+func TestShouldSupportOptionalPtrFromRegex(t *testing.T) {
+	intRe := regexp.MustCompile(`^I have (\d+)(?: and (\d+))?$`)
+	floatRe := regexp.MustCompile(`^I have (\S+)(?: and (\S+))?$`)
+
+	cases := []struct {
+		name     string
+		re       *regexp.Regexp
+		present  string
+		absent   string
+		expected interface{}
+	}{
+		{"*int", intRe, "I have 1 and 42", "I have 1", 42},
+		{"*int8", intRe, "I have 1 and 42", "I have 1", int8(42)},
+		{"*int16", intRe, "I have 1 and 42", "I have 1", int16(42)},
+		{"*int32", intRe, "I have 1 and 42", "I have 1", int32(42)},
+		{"*int64", intRe, "I have 1 and 42", "I have 1", int64(42)},
+		{"*uint", intRe, "I have 1 and 42", "I have 1", uint(42)},
+		{"*uint8", intRe, "I have 1 and 42", "I have 1", uint8(42)},
+		{"*uint16", intRe, "I have 1 and 42", "I have 1", uint16(42)},
+		{"*uint32", intRe, "I have 1 and 42", "I have 1", uint32(42)},
+		{"*uint64", intRe, "I have 1 and 42", "I have 1", uint64(42)},
+		{"*float32", floatRe, "I have 1.0 and 3.14", "I have 1.0", float32(3.14)},
+		{"*float64", floatRe, "I have 1.0 and 3.14", "I have 1.0", float64(3.14)},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			elemType := reflect.TypeOf(c.expected)
+			ptrType := reflect.PointerTo(elemType)
+
+			var got interface{}
+			fnType := reflect.FuncOf([]reflect.Type{elemType, ptrType}, nil, false)
+			handler := reflect.MakeFunc(fnType, func(args []reflect.Value) []reflect.Value {
+				if args[1].IsNil() {
+					got = nil
+				} else {
+					got = args[1].Elem().Interface()
+				}
+				return nil
+			}).Interface()
+
+			run := func(text string) interface{} {
+				m := c.re.FindStringSubmatch(text)
+				if len(m) == 0 {
+					t.Fatalf("regex did not match %q", text)
+				}
+				var args []interface{}
+				for _, g := range m[1:] {
+					args = append(args, g)
+				}
+				def := &models.StepDefinition{
+					StepDefinition: formatters.StepDefinition{Handler: handler},
+					HandlerValue:   reflect.ValueOf(handler),
+					Args:           args,
+				}
+				_, res := def.Run(context.Background())
+				return res
+			}
+
+			got = "sentinel"
+			assert.Nil(t, run(c.present))
+			assert.Equal(t, c.expected, got)
+
+			got = "sentinel"
+			assert.Nil(t, run(c.absent))
+			assert.Nil(t, got)
+		})
+	}
+}
+
 func TestShouldSupportGherkinDocstring(t *testing.T) {
 	var actualDocString *messages.PickleDocString
 	fnDocstring := func(a *messages.PickleDocString) {
@@ -556,16 +688,8 @@ func TestStepDefinition_Run_InvalidHandlerParamConversion(t *testing.T) {
 
 	// Lists some unsupported argument types for step handler.
 
-	// Pointers should work only for godog.Table/godog.DocString
-	test(t, func(a *int) { shouldNotBeCalled() }, "func has unsupported parameter type: the data type of parameter 0 type *int is not supported")
-	test(t, func(a *int64) { shouldNotBeCalled() }, "func has unsupported parameter type: the data type of parameter 0 type *int64 is not supported")
-	test(t, func(a *int32) { shouldNotBeCalled() }, "func has unsupported parameter type: the data type of parameter 0 type *int32 is not supported")
-	test(t, func(a *int16) { shouldNotBeCalled() }, "func has unsupported parameter type: the data type of parameter 0 type *int16 is not supported")
-	test(t, func(a *int8) { shouldNotBeCalled() }, "func has unsupported parameter type: the data type of parameter 0 type *int8 is not supported")
+	// Only pointers to numeric types (int/uint/float) and godog.Table/godog.DocString are supported.
 	test(t, func(a *string) { shouldNotBeCalled() }, "func has unsupported parameter type: the data type of parameter 0 type *string is not supported")
-	test(t, func(a *float64) { shouldNotBeCalled() }, "func has unsupported parameter type: the data type of parameter 0 type *float64 is not supported")
-	test(t, func(a *float32) { shouldNotBeCalled() }, "func has unsupported parameter type: the data type of parameter 0 type *float32 is not supported")
-
 	// I cannot pass structures
 	test(t, func(a godog.Table) { shouldNotBeCalled() }, "func has unsupported parameter type: the struct parameter 0 type messages.PickleTable is not supported")
 	test(t, func(a godog.DocString) { shouldNotBeCalled() }, "func has unsupported parameter type: the struct parameter 0 type messages.PickleDocString is not supported")


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

This would support int/uint/float pointer as parameter in step functions

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->


I'm a contributor to [Apache iggy](https://github.com/apache/iggy), I'm planning to add a BDD test scenario for it.
Here is the use case I have:

I have the following steps for different sceanarios.
```
    Given I have a running Iggy server whose network may be disrupted
    And reconnection is enabled with 3 retries and 2 seconds interval
```

```
    Given I have a running Iggy server whose network may be disrupted
    And reconnection is disabled
```

Currently, this is what I'm doing

```go
func (s reconnectSteps) setReconnection(ctx context.Context, state string, retries string, interval string) error {
	c := getReconnectCtx(ctx)

	enable := state == "enabled"
	var opts []tcp.ReconnectionOption

	// TODO: currently godog doesn't support optional int/uint parameters, change to proper optional parameters once godog supports it
	if retries != "" {
		maxRetries, _ := strconv.ParseUint(retries, 10, 32)
		opts = append(opts, tcp.WithMaxRetries(uint32(maxRetries)))
	}
	if interval != "" {
		secs, _ := strconv.Atoi(interval)
		opts = append(opts, tcp.WithRetryInterval(time.Duration(secs)*time.Second))
	}

	if !enable && len(opts) != 0 {
		return fmt.Errorf("reconnection disabled but other options are provided, this test case is invalid")
	}

	c.tcpOpts = append(c.tcpOpts, tcp.WithReconnection(enable, opts...))
	return nil
}
```
```go
sc.Step(`^reconnection is (enabled|disabled)(?: with (\d+) retries and (\d+) seconds interval)?$`, s.setReconnection)
```
I hate to do parse the string to uint/int when writing my test, so I hope I can support optional parameter using pointer in godog.


Here is what my function would be like if this feature is implemented.

```go
func (s reconnectSteps) setReconnection(ctx context.Context, state string, retries *uint32, interval *int) error
```



I don't want to 

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

I'm not sure if this would be accepted, so I will delay adding the document (since I hate writing), also the CHANGELOG.md

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
