### PR TITLE
fix: recover from panics in after-step and after-scenario hooks (#662)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 ## Unreleased
 
+### Fixed
+- A panic inside an after-step or after-scenario hook is now recovered and reported as a failure instead of crashing the goroutine, consistent with before hooks - ([662](https://github.com/cucumber/godog/issues/662) - [nikolauspschuetz](https://github.com/nikolauspschuetz))
+
 ## [v0.15.1]
 
 ### Added

--- a/suite.go
+++ b/suite.go
@@ -293,6 +293,29 @@ func (s *suite) runStep(ctx context.Context, pickle *Scenario, step *Step, scena
 	return ctx, err
 }
 
+// recoveredHookError converts a value recovered from a panic inside an after
+// hook into an error, folding it into any error the hooks have already produced.
+// It mirrors the panic-to-error handling of runStep's deferred recover so that a
+// panic in a post hook is reported as a failure rather than crashing the
+// goroutine. A FailNow/SkipNow (errStopNow) panic is preserved unchanged so the
+// normal testingT failure handling still applies.
+func recoveredHookError(label string, recovered interface{}, existing error) error {
+	if pe, ok := recovered.(error); ok && errors.Is(pe, errStopNow) {
+		return pe
+	}
+
+	panicErr := &traceError{
+		msg:   fmt.Sprintf("%s panicked: %v", label, recovered),
+		stack: callStack(),
+	}
+
+	if existing == nil {
+		return panicErr
+	}
+
+	return fmt.Errorf("%v, %w", panicErr, existing)
+}
+
 func (s *suite) runBeforeStepHooks(ctx context.Context, step *Step, err error) (context.Context, error) {
 	hooksFailed := false
 
@@ -320,25 +343,36 @@ func (s *suite) runBeforeStepHooks(ctx context.Context, step *Step, err error) (
 	return ctx, err
 }
 
-func (s *suite) runAfterStepHooks(ctx context.Context, step *Step, status StepResultStatus, err error) (context.Context, error) {
+func (s *suite) runAfterStepHooks(ctx context.Context, step *Step, status StepResultStatus, err error) (rctx context.Context, rerr error) {
+	rctx, rerr = ctx, err
+
+	// After step hooks are user-provided and may panic. Recover so a panic in an
+	// after hook is reported as a failure instead of crashing the goroutine,
+	// mirroring how panics in before hooks and steps are handled in runStep.
+	defer func() {
+		if e := recover(); e != nil {
+			rerr = recoveredHookError("after step hook", e, rerr)
+		}
+	}()
+
 	for _, f := range s.afterStepHandlers {
-		hctx, herr := f(ctx, step, status, err)
+		hctx, herr := f(rctx, step, status, rerr)
 
 		// Adding hook error to resulting error without breaking hooks loop.
 		if herr != nil {
-			if err == nil {
-				err = herr
+			if rerr == nil {
+				rerr = herr
 			} else {
-				err = fmt.Errorf("%v, %w", herr, err)
+				rerr = fmt.Errorf("%v, %w", herr, rerr)
 			}
 		}
 
 		if hctx != nil {
-			ctx = hctx
+			rctx = hctx
 		}
 	}
 
-	return ctx, err
+	return rctx, rerr
 }
 
 func (s *suite) runBeforeScenarioHooks(ctx context.Context, pickle *messages.Pickle) (context.Context, error) {
@@ -367,42 +401,51 @@ func (s *suite) runBeforeScenarioHooks(ctx context.Context, pickle *messages.Pic
 	return ctx, err
 }
 
-func (s *suite) runAfterScenarioHooks(ctx context.Context, pickle *messages.Pickle, lastStepErr error) (context.Context, error) {
-	err := lastStepErr
+func (s *suite) runAfterScenarioHooks(ctx context.Context, pickle *messages.Pickle, lastStepErr error) (rctx context.Context, rerr error) {
+	rctx, rerr = ctx, lastStepErr
+
+	// After scenario hooks are user-provided and may panic. Recover so a panic in
+	// an after hook is reported as a failure instead of crashing the goroutine,
+	// mirroring how panics in before hooks and steps are handled in runStep.
+	defer func() {
+		if e := recover(); e != nil {
+			rerr = recoveredHookError("after scenario hook", e, rerr)
+		}
+	}()
 
 	hooksFailed := false
 	isStepErr := true
 
 	// run after scenario handlers
 	for _, f := range s.afterScenarioHandlers {
-		hctx, herr := f(ctx, pickle, err)
+		hctx, herr := f(rctx, pickle, rerr)
 
 		// Adding hook error to resulting error without breaking hooks loop.
 		if herr != nil {
 			hooksFailed = true
 
-			if err == nil {
+			if rerr == nil {
 				isStepErr = false
-				err = herr
+				rerr = herr
 			} else {
 				if isStepErr {
-					err = fmt.Errorf("step error: %w", err)
+					rerr = fmt.Errorf("step error: %w", rerr)
 					isStepErr = false
 				}
-				err = fmt.Errorf("%v, %w", herr, err)
+				rerr = fmt.Errorf("%v, %w", herr, rerr)
 			}
 		}
 
 		if hctx != nil {
-			ctx = hctx
+			rctx = hctx
 		}
 	}
 
 	if hooksFailed {
-		err = fmt.Errorf("after scenario hook failed: %w", err)
+		rerr = fmt.Errorf("after scenario hook failed: %w", rerr)
 	}
 
-	return ctx, err
+	return rctx, rerr
 }
 
 func (s *suite) maybeUndefined(ctx context.Context, text string, arg interface{}, stepType messages.PickleStepType) (context.Context, []string, error) {

--- a/suite_context_test.go
+++ b/suite_context_test.go
@@ -950,6 +950,65 @@ Feature: dummy
 	}
 }
 
+// TestPanicInAfterHookIsRecovered verifies that a panic inside a post hook
+// (after-step or after-scenario) is recovered and reported as a failure instead
+// of crashing the goroutine, consistent with how panics in pre hooks and steps
+// are handled. Regression test for https://github.com/cucumber/godog/issues/662.
+//
+// If the panic were not recovered, the panic would propagate out of suite.Run
+// and crash this test process, so simply not crashing already proves recovery;
+// we additionally assert the failure is surfaced (non-zero status + reported).
+func TestPanicInAfterHookIsRecovered(t *testing.T) {
+	feature := []byte("Feature: f\n  Scenario: s\n    When foo\n")
+
+	for _, tc := range []struct {
+		name      string
+		panicText string
+		init      func(sc *ScenarioContext, panicText string)
+	}{
+		{
+			name:      "after step hook",
+			panicText: "boom in after step hook",
+			init: func(sc *ScenarioContext, panicText string) {
+				sc.StepContext().After(func(ctx context.Context, step *Step, status StepResultStatus, err error) (context.Context, error) {
+					panic(panicText)
+				})
+			},
+		},
+		{
+			name:      "after scenario hook",
+			panicText: "boom in after scenario hook",
+			init: func(sc *ScenarioContext, panicText string) {
+				sc.After(func(ctx context.Context, s *Scenario, err error) (context.Context, error) {
+					panic(panicText)
+				})
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+
+			suite := TestSuite{
+				ScenarioInitializer: func(sc *ScenarioContext) {
+					sc.When(`^foo$`, func() {})
+					tc.init(sc, tc.panicText)
+				},
+				Options: &Options{
+					Format:          "pretty",
+					Output:          colors.Uncolored(&buf),
+					FeatureContents: []Feature{{Name: "f", Contents: feature}},
+				},
+			}
+
+			// Reaching this line at all proves the panic did not crash the goroutine.
+			status := suite.Run()
+
+			assert.Equal(t, exitFailure, status, "panicking after hook must fail the suite, not crash")
+			assert.Contains(t, buf.String(), tc.panicText, "the recovered panic should be reported")
+		})
+	}
+}
+
 func TestTestSuite_Run(t *testing.T) {
 	for _, tc := range []struct {
 		name          string


### PR DESCRIPTION
## Problem

A panic inside a **post hook** (after-step or after-scenario) kills the goroutine and breaks error reporting, while a panic in a **pre hook** is gracefully captured and reported as a failure. Reported in #662.

## Root cause (asymmetry)

In `suite.runStep` (`suite.go`), the deferred function installs `recover()` for the step body and the *before* hooks (`runBeforeStepHooks` / `runBeforeScenarioHooks` run in the main body, so their panics are caught).

But `runAfterStepHooks` and `runAfterScenarioHooks` are invoked **inside that same deferred function** (`suite.go:185` and `suite.go:189`), *after* the `recover()` at `suite.go:138` has already returned. A panic raised while a deferred function is executing is not caught by an earlier `recover()` in that same deferred function — so an after-hook panic propagates out and crashes the goroutine.

## Fix

Give the after-hook loops their own `defer/recover`, converting a recovered panic into a reported `traceError` that is folded into the existing hook error chain — mirroring `runStep`'s own panic-to-error handling, including the `errStopNow` special case used by `FailNow`/`SkipNow`. A small shared helper `recoveredHookError` keeps both paths identical. Pre and post hook panics are now handled symmetrically. Minimal, behavior-only change in `suite.go`.

## Test evidence

Added `TestPanicInAfterHookIsRecovered` (table test: after-step hook + after-scenario hook). Reaching the assertions at all proves the panic no longer crashes the goroutine; it additionally asserts the suite returns a failure status and the panic text is reported.

- **Without the fix:** the test crashes the process — `panic: boom in after step hook [recovered, repanicked]`.
- **With the fix:** `--- PASS: TestPanicInAfterHookIsRecovered` (both subtests).
- `go test ./...` — all packages pass.
- `go build ./...`, `go vet ./...`, `gofmt -l` — clean.

Closes #662

### AI assistance

This change was prepared with the assistance of Claude Code (Anthropic, Opus 4.x): code exploration, the fix, and the regression test. All changes were reviewed and verified locally (failing-without-fix / passing-with-fix confirmed, full suite green). The commit carries an `Assisted-by` trailer.
