### PR TITLE
fix(tags): don't panic on tag filters with empty operands

### DIFF
--- a/internal/tags/tag_filter.go
+++ b/internal/tags/tag_filter.go
@@ -39,6 +39,14 @@ func matchAnd(filter string, tags []*messages.PickleTag) bool {
 	for _, tag := range strings.Split(filter, "&&") {
 		tag = strings.TrimSpace(tag)
 		tag = strings.Replace(tag, "@", "", -1)
+		if tag == "" {
+			// An empty operand comes from a malformed filter such as
+			// "@one,,@two", a trailing "@one," or "@one&&". An empty tag can
+			// never be present on a pickle, so it fails the AND (consistent
+			// with the else branch below) instead of panicking on tag[0].
+			and = false
+			continue
+		}
 		if tag[0] == '~' {
 			tag = tag[1:]
 			and = !contains(tags, tag) && and

--- a/internal/tags/tag_filter_test.go
+++ b/internal/tags/tag_filter_test.go
@@ -43,6 +43,15 @@ func Test_ApplyTagFilter(t *testing.T) {
 		{filter: "@one&&@wip,@wip&&@two", expected: []*pickle{p1, p2}},
 		{filter: "@one&&@two,@one&&@wip,@wip&&@two", expected: []*pickle{p1, p2}},
 		{filter: "@two&&@one,@one&&@wip,@three&&@two", expected: []*pickle{p1}},
+
+		// malformed filters with empty operands must not panic: an empty
+		// operand can never match, so it is ignored for OR (commas) and
+		// fails the AND (&&).
+		{filter: "@one,,@two", expected: []*pickle{p1, p2}},
+		{filter: "@one,", expected: []*pickle{p1}},
+		{filter: ",@one", expected: []*pickle{p1}},
+		{filter: "@one&&", expected: []*pickle{}},
+		{filter: "@one&&&&@two", expected: []*pickle{}},
 	} {
 		t.Run("", func(t *testing.T) {
 			actual := tags.ApplyTagFilter(tc.filter, testdata)


### PR DESCRIPTION
## Summary

`ApplyTagFilter` panics on a `--tags` filter that contains an empty operand.

`matchAnd` trims each operand and strips `@`, then immediately indexes `tag[0]`:

```go
tag = strings.TrimSpace(tag)
tag = strings.Replace(tag, "@", "", -1)
if tag[0] == '~' {   // panics when tag == ""
```

Any filter that splits to an empty operand triggers `runtime error: index out of range [0] with length 0`:

- `@one,,@two` (double comma)
- `@one,` (trailing comma)
- `,@one` (leading comma)
- `@one&&` (trailing `&&`)
- `@one&&&&@two` (double `&&`)

Since the filter string comes straight from user input (`-t/--tags`), a small typo crashes the whole run with a stack trace instead of a graceful result.

## Fix

Guard the empty operand before indexing. An empty tag can never be present on a pickle, so it fails the `AND` — identical to what the existing `else` branch (`contains(tags, "")` → `false`) would compute if it were reachable — and is harmlessly ignored for the `OR` (comma) case:

```go
tag = strings.Replace(tag, "@", "", -1)
if tag == "" {
    and = false
    continue
}
if tag[0] == '~' {
```

## Tests

Added regression cases to `Test_ApplyTagFilter` for all five malformed filters above (each previously panicked; behaviour: `@one,,@two` → `{p1, p2}`, `@one,` → `{p1}`, `,@one` → `{p1}`, `@one&&` → `{}`, `@one&&&&@two` → `{}`).

Verified:
- Reproduced the panic on `main` (`index out of range [0] with length 0`).
- `go test ./internal/tags/` — passes with the new cases.
- `go vet` + `gofmt` clean.