### PR TITLE
test(formatters): FailNow on the running subtest, not the parent

### DIFF
--- a/internal/formatters/fmt_output_test.go
+++ b/internal/formatters/fmt_output_test.go
@@ -22,7 +22,6 @@ const fmtOutputTestsFeatureDir = "formatter-tests/features"
 var tT *testing.T
 
 func Test_FmtOutput(t *testing.T) {
-	tT = t
 	pkg := os.Getenv("GODOG_TESTED_PACKAGE")
 	os.Setenv("GODOG_TESTED_PACKAGE", "github.com/cucumber/godog")
 
@@ -152,6 +151,10 @@ func fmtOutputTest(fmtName, testName, featureFilePath string) func(*testing.T) {
 	}
 
 	return func(t *testing.T) {
+		// Point tT at the currently running subtest so the scenario/step hooks
+		// below call FailNow on this subtest, on its own goroutine, rather than
+		// on the parent Test_FmtOutput (which is unsafe from a subtest goroutine).
+		tT = t
 		fmt.Printf("fmt_output_test for format %10s : sample file %v\n", fmtName, featureFilePath)
 		expectOutputPath := strings.Replace(featureFilePath, "features", fmtName, 1)
 		expectOutputPath = strings.TrimSuffix(expectOutputPath, path.Ext(expectOutputPath))


### PR DESCRIPTION
## Summary

`Test_FmtOutput` runs each formatter/feature combination as a `t.Run(...)` subtest, and the scenario/step hooks registered in `fmtOutputTest` call `assert.FailNow(tT, ...)` when they find unexpected attachments. But `tT` is a package-level `*testing.T` set **once** to the parent `Test_FmtOutput`:

```go
var tT *testing.T

func Test_FmtOutput(t *testing.T) {
    tT = t
    ...
    t.Run(testName, fmtOutputTest(...))   // hooks inside call FailNow(tT)
```

So a hook running inside a subtest calls `FailNow` on the **parent** test, from the **subtest's** goroutine. `testing` documents that `FailNow` must be called from the goroutine running the test it belongs to; calling it on the parent from a child goroutine can misattribute the failure or mishandle the `Goexit`, rather than cleanly failing the specific subtest that broke.

## Fix

Assign `tT` to the current subtest's `*testing.T` at the start of each returned test function, so `FailNow` targets the subtest that is actually running, on its own goroutine:

```go
return func(t *testing.T) {
    tT = t
    ...
```

Subtests here run serially (no `t.Parallel()`) and godog runs the scenarios serially (no `Options.Concurrency`), so the shared `tT` is only ever written/read for the one subtest in flight — no data race.

## Verification

- `go test ./internal/formatters/` — passes (`ok ... 0.764s`); no behaviour change on the passing path.
- `gofmt` / `go vet` clean.

This is a correctness fix on the failure path (a mis-targeted `FailNow` only manifests when a hook assertion actually fails), so it does not change the green-path output; the value is that a real failure now fails the right subtest cleanly.