### PR TITLE
fix(hooks): wrap errors to preserve sentinel values

### DIFF
--- a/suite.go
+++ b/suite.go
@@ -304,7 +304,7 @@ func (s *suite) runBeforeStepHooks(ctx context.Context, step *Step, err error) (
 			if err == nil {
 				err = herr
 			} else {
-				err = fmt.Errorf("%v, %w", herr, err)
+				err = mergeErrors(herr, err)
 			}
 		}
 
@@ -329,7 +329,7 @@ func (s *suite) runAfterStepHooks(ctx context.Context, step *Step, status StepRe
 			if err == nil {
 				err = herr
 			} else {
-				err = fmt.Errorf("%v, %w", herr, err)
+				err = mergeErrors(herr, err)
 			}
 		}
 
@@ -351,7 +351,7 @@ func (s *suite) runBeforeScenarioHooks(ctx context.Context, pickle *messages.Pic
 			if err == nil {
 				err = herr
 			} else {
-				err = fmt.Errorf("%v, %w", herr, err)
+				err = mergeErrors(herr, err)
 			}
 		}
 
@@ -389,7 +389,7 @@ func (s *suite) runAfterScenarioHooks(ctx context.Context, pickle *messages.Pick
 					err = fmt.Errorf("step error: %w", err)
 					isStepErr = false
 				}
-				err = fmt.Errorf("%v, %w", herr, err)
+				err = mergeErrors(herr, err)
 			}
 		}
 
@@ -648,4 +648,35 @@ func (s *suite) runPickle(pickle *messages.Pickle) (err error) {
 	// so that error from handler can be added to step.
 
 	return err
+}
+
+type joinedError struct {
+	err1 error
+	err2 error
+}
+
+func (e *joinedError) Error() string {
+	return fmt.Sprintf("%v, %v", e.err1, e.err2)
+}
+
+func (e *joinedError) Unwrap() []error {
+	return []error{e.err1, e.err2}
+}
+
+func (e *joinedError) Is(target error) bool {
+	return errors.Is(e.err1, target) || errors.Is(e.err2, target)
+}
+
+func (e *joinedError) As(target interface{}) bool {
+	return errors.As(e.err1, target) || errors.As(e.err2, target)
+}
+
+func mergeErrors(err1, err2 error) error {
+	if err1 == nil {
+		return err2
+	}
+	if err2 == nil {
+		return err1
+	}
+	return &joinedError{err1: err1, err2: err2}
 }

--- a/suite_context_test.go
+++ b/suite_context_test.go
@@ -1253,3 +1253,58 @@ func TestTestSuite_Run(t *testing.T) {
 		})
 	}
 }
+
+func TestSuite_HookErrorWrapping(t *testing.T) {
+	stepErr := errors.New("intentional step failure")
+	hook1Err := errors.New("hook 1 failure")
+	hook2Err := ErrSkip
+
+	var capturedErr error
+
+	suite := TestSuite{
+		Name: "hook_error_wrapping",
+		ScenarioInitializer: func(sc *ScenarioContext) {
+			sc.Step(`^a failing step$`, func() error {
+				return stepErr
+			})
+
+			// Hook 1: Returns hook1Err
+			sc.StepContext().After(func(ctx context.Context, step *Step, status StepResultStatus, err error) (context.Context, error) {
+				if err != nil {
+					return ctx, hook1Err
+				}
+				return ctx, nil
+			})
+
+			// Hook 2: Returns hook2Err (ErrSkip)
+			sc.StepContext().After(func(ctx context.Context, step *Step, status StepResultStatus, err error) (context.Context, error) {
+				if err != nil {
+					return ctx, hook2Err
+				}
+				return ctx, nil
+			})
+
+			// Capture the final merged error in AfterScenario hook
+			sc.After(func(ctx context.Context, sc *Scenario, err error) (context.Context, error) {
+				capturedErr = err
+				return ctx, nil
+			})
+		},
+		Options: &Options{
+			Format:   "progress",
+			NoColors: true,
+			FeatureContents: []Feature{
+				{
+					Name:     "hook_error_wrapping",
+					Contents: []byte("Feature: test\n  Scenario: test\n    When a failing step\n"),
+				},
+			},
+		},
+	}
+
+	suite.Run()
+
+	assert.ErrorIs(t, capturedErr, stepErr)
+	assert.ErrorIs(t, capturedErr, hook1Err)
+	assert.ErrorIs(t, capturedErr, hook2Err)
+}


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

This PR fixes hook error wrapping to preserve the types of all merged errors. 

Specifically:
*   Introduces a custom `joinedError` type and `mergeErrors` helper at the end of [suite.go](./suite.go).
*   Updates `runBeforeStepHooks`, `runAfterStepHooks`, `runBeforeScenarioHooks`, and `runAfterScenarioHooks` in [suite.go](./suite.go) to use `mergeErrors` instead of `fmt.Errorf("%v, %w")`.
*   This ensures that all errors returned from hook handlers are correctly wrapped, making them fully detectable by `errors.Is` and `errors.As`.

**Backward Compatibility**:
*   **Go 1.18 - 1.19**: Supported via the custom `Is` and `As` methods on `joinedError`, which have been natively supported by the standard `errors` package since Go 1.13.
*   **Go 1.20+**: Supported via the `Unwrap() []error` method, allowing modern Go runtimes and static analysis tools to natively unwrap the error slice.
*   **Error Messages**: Preserves the original `%v, %v` string formatting, ensuring no breaking changes to logs or output formatting.

### ⚡️ What's your motivation? 

Fixes #732

Currently, when a step fails and a hook also returns an error (such as a skip), they are merged using `fmt.Errorf("%v, %w")`. This prevents `errors.Is` and `errors.As` from detecting the hook error type because it is formatted with `%v` instead of `%w`. As a result, the runner fails to recognize sentinel errors like `ErrSkip` returned from hooks when a step fails.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

Feedback on the `joinedError` implementation for Go versions < 1.20 (which do not support multiple `%w` verbs).

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
