### PR TITLE
feat: support bool type parameter in step functions

### DIFF
--- a/internal/models/stepdef.go
+++ b/internal/models/stepdef.go
@@ -188,6 +188,16 @@ func (sd *StepDefinition) Run(ctx context.Context) (context.Context, interface{}
 				return ctx, fmt.Errorf(`%w %d: "%s" to float32: %s`, ErrCannotConvert, i, s, err)
 			}
 			values = append(values, reflect.ValueOf(float32(v)))
+		case reflect.Bool:
+			s, err := sd.shouldBeString(i)
+			if err != nil {
+				return ctx, err
+			}
+			v, err := strconv.ParseBool(s)
+			if err != nil {
+				return ctx, fmt.Errorf(`%w %d: "%s" to bool: %s`, ErrCannotConvert, i, s, err)
+			}
+			values = append(values, reflect.ValueOf(v))
 		case reflect.Ptr:
 			arg := sd.Args[i]
 			switch param.Elem().String() {

--- a/internal/models/stepdef_test.go
+++ b/internal/models/stepdef_test.go
@@ -400,6 +400,48 @@ func TestShouldSupportFloatTypes(t *testing.T) {
 	assert.Equal(t, `cannot convert argument 1: "22222222222222222222222222222222222222222222222222222222222222222.22" to float32: strconv.ParseFloat: parsing "22222222222222222222222222222222222222222222222222222222222222222.22": value out of range`, err.(error).Error())
 }
 
+func TestShouldSupportBoolType(t *testing.T) {
+	var aActual bool
+	var bActual bool
+	fn := func(a bool, b bool) {
+		aActual = a
+		bActual = b
+	}
+
+	def := &models.StepDefinition{
+		StepDefinition: formatters.StepDefinition{
+			Handler: fn,
+		},
+		HandlerValue: reflect.ValueOf(fn),
+	}
+
+	// Test "true" and "false"
+	def.Args = []interface{}{"true", "false"}
+	_, err := def.Run(context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, true, aActual)
+	assert.Equal(t, false, bActual)
+
+	// Test "1" and "0"
+	def.Args = []interface{}{"1", "0"}
+	_, err = def.Run(context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, true, aActual)
+	assert.Equal(t, false, bActual)
+
+	// Test "TRUE" and "FALSE"
+	def.Args = []interface{}{"TRUE", "FALSE"}
+	_, err = def.Run(context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, true, aActual)
+	assert.Equal(t, false, bActual)
+
+	// Test invalid bool string
+	def.Args = []interface{}{"yes", "no"}
+	_, err = def.Run(context.Background())
+	assert.Equal(t, `cannot convert argument 0: "yes" to bool: strconv.ParseBool: parsing "yes": invalid syntax`, err.(error).Error())
+}
+
 func TestShouldSupportGherkinDocstring(t *testing.T) {
 	var actualDocString *messages.PickleDocString
 	fnDocstring := func(a *messages.PickleDocString) {
@@ -581,7 +623,7 @@ func TestStepDefinition_Run_InvalidHandlerParamConversion(t *testing.T) {
 	test(t, func(a []bool) { shouldNotBeCalled() }, "func has unsupported parameter type: the slice parameter 0 type []bool is not supported")
 
 	// // I cannot use bool
-	test(t, func(a bool) { shouldNotBeCalled() }, "func has unsupported parameter type: the parameter 0 type bool is not supported")
+	// bool is now supported - see TestShouldSupportBoolType
 
 }
 

--- a/internal/models/stepdef_test.go
+++ b/internal/models/stepdef_test.go
@@ -436,11 +436,15 @@ func TestShouldSupportBoolType(t *testing.T) {
 	assert.Equal(t, true, aActual)
 	assert.Equal(t, false, bActual)
 
+	// Test non-string argument type (should fail before parsing)
+	def.Args = []interface{}{12, "false"}
+	_, err = def.Run(context.Background())
+	assert.Equal(t, `cannot convert argument 0: "12" of type "int" to string`, err.(error).Error())
+
 	// Test invalid bool string
 	def.Args = []interface{}{"yes", "no"}
 	_, err = def.Run(context.Background())
 	assert.Equal(t, `cannot convert argument 0: "yes" to bool: strconv.ParseBool: parsing "yes": invalid syntax`, err.(error).Error())
-}
 
 func TestShouldSupportGherkinDocstring(t *testing.T) {
 	var actualDocString *messages.PickleDocString


### PR DESCRIPTION
## What's changed?

This PR adds support for `bool` as a parameter type in step handler functions.

Previously, using `bool` in a step function would result in:

```
func has unsupported parameter type: the parameter 0 type bool is not supported
```

Now you can write step definitions like:

```go
ctx.Step(`^feature is enabled: (true|false)$`, func(enabled bool) error {
    // enabled is automatically parsed from the string
    ...
})
```

## How it works

Uses `strconv.ParseBool` which accepts the following string values:

- `true`: `"1"`, `"t"`, `"T"`, `"TRUE"`, `"true"`, `"True"`
- `false`: `"0"`, `"f"`, `"F"`, `"FALSE"`, `"false"`, `"False"`

## Changes

- `internal/models/stepdef.go`: Added `reflect.Bool` case in the `Run()` type switch
- `internal/models/stepdef_test.go`: Added `TestShouldSupportBoolType` test and updated the invalid-type test to reflect that `bool` is now supported

## Related

Related to #747 (optional parameters for int/uint/float types)
